### PR TITLE
Move install.sh into m87-client and make POSIX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,18 +180,18 @@ jobs:
       - name: Add install script to release
         run: |
           # install.sh already has the correct version from the version-update workflow
-          cp install.sh release-assets/
-          chmod +x release-assets/install.sh
-          echo "Added install.sh to release assets"
+          cp m87-client/install.sh release-assets/install-client.sh
+          chmod +x release-assets/install-client.sh
+          echo "Added install-client.sh to release assets"
           # Verify the version is set correctly
-          grep "^VERSION=" release-assets/install.sh
-          ls -lh release-assets/install.sh
+          grep "^VERSION=" release-assets/install-client.sh
+          ls -lh release-assets/install-client.sh
 
       - name: Generate checksums
         run: |
           cd release-assets
           # Generate SHA256 checksums for all files (SHA256SUMS will be created after, so it won't include itself)
-          sha256sum m87-* install.sh > SHA256SUMS
+          sha256sum m87-* install-client.sh > SHA256SUMS
           echo "Generated checksums:"
           cat SHA256SUMS
 

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Update version in install.sh
         run: |
           VERSION="${{ steps.extract-version.outputs.version }}"
-          sed -i "s/^VERSION=\"__VERSION__\"/VERSION=\"$VERSION\"/" install.sh
-          echo "Updated install.sh to version $VERSION"
-          grep "^VERSION=" install.sh
+          sed -i "s/^VERSION=\"__VERSION__\"/VERSION=\"$VERSION\"/" m87-client/install.sh
+          echo "Updated m87-client/install.sh to version $VERSION"
+          grep "^VERSION=" m87-client/install.sh
 
       - name: Update Docker image tag in docker-compose.yml
         run: |
@@ -86,6 +86,6 @@ jobs:
           VERSION="${{ steps.extract-version.outputs.version }}"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add m87-client/Cargo.toml m87-server/Cargo.toml m87-shared/Cargo.toml tests/Cargo.toml install.sh m87-server/docker-compose.yml Cargo.lock
+          git add m87-client/Cargo.toml m87-server/Cargo.toml m87-shared/Cargo.toml tests/Cargo.toml m87-client/install.sh m87-server/docker-compose.yml Cargo.lock
           git commit -m "chore: bump version to $VERSION" || echo "No changes to commit"
           git push || echo "No changes to push"


### PR DESCRIPTION
Rename install.sh to m87-client/install.sh and change shebang to /bin/sh Update GitHub workflows to reference m87-client/install.sh and add the release asset as install-client.sh Make the installer POSIX-friendly: replace bash-only constructs (local arrays, -e echo) with portable equivalents, use printf, and adjust variable usage for /bin/sh compatibility