### PR TITLE
feat(p2p): add iroh-based direct P2P connections with tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,6 +73,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Exposes ACTIONS_CACHE_URL / ACTIONS_RUNTIME_TOKEN to plain `run` steps so
+      # the `docker buildx build --cache-to type=gha` in setup.rs can reach the
+      # GitHub Actions cache (setup-buildx-action does not export these itself).
+      - name: Expose GitHub Actions cache to buildx
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -89,8 +89,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-e2e-
 
+      # Compile the binaries once, on the host, reusing the cached `target/`.
+      # setup.rs bakes these into slim COPY-only images (Dockerfile.e2e) instead
+      # of doing two cold in-Docker compiles. Doing it as its own step keeps the
+      # heavy compile out of the test process and cache-friendly.
+      - name: Build e2e binaries (host, cached)
+        run: |
+          cargo build -p m87-server
+          cargo build -p m87-client --features runtime,cli
+
+      # Tests isolate by a per-run_id prefix on every container name and address
+      # each other by those names / by iroh node-id, so they run concurrently.
+      # 4 threads => up to 4 container stacks at once on the 4-vCPU/16GB runner.
       - name: Run E2E tests
-        run: cargo test --manifest-path tests/Cargo.toml --features e2e -- --nocapture --test-threads=1
+        run: cargo test --manifest-path tests/Cargo.toml --features e2e -- --test-threads=4
 
       # Cleanup is scoped by the `e2e-*` name prefix that tests apply when
       # creating containers (see tests/src/e2e_containers/containers.rs).

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -106,9 +106,10 @@ jobs:
 
       # Tests isolate by a per-run_id prefix on every container name and address
       # each other by those names / by iroh node-id, so they run concurrently.
-      # 4 threads => up to 4 container stacks at once on the 4-vCPU/16GB runner.
+      # 2 stacks at a time on the 4-vCPU/16GB runner: 4 was flaky (server-readiness
+      # races + iroh P2P drops under CPU contention), 2 keeps headroom.
       - name: Run E2E tests
-        run: cargo test --manifest-path tests/Cargo.toml --features e2e -- --test-threads=4
+        run: cargo test --manifest-path tests/Cargo.toml --features e2e -- --test-threads=2
 
       # Cleanup is scoped by the `e2e-*` name prefix that tests apply when
       # creating containers (see tests/src/e2e_containers/containers.rs).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
 
@@ -171,6 +171,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-compression"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,10 +227,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "autocfg"
@@ -350,6 +394,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,7 +436,7 @@ checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
 dependencies = [
  "blowfish",
  "pbkdf2",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -432,7 +487,21 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -445,12 +514,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -651,7 +738,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -702,6 +789,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -774,6 +876,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,12 +902,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
 ]
 
 [[package]]
@@ -967,6 +1091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,9 +1136,27 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
  "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -1132,9 +1292,29 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "delegate"
@@ -1159,8 +1339,19 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1197,6 +1388,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,15 +1442,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1249,7 +1488,19 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1261,6 +1512,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -1296,12 +1558,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1310,8 +1572,19 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+dependencies = [
+ "pkcs8 0.11.0-rc.10",
+ "serde",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1320,12 +1593,28 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "ed25519 3.0.0-rc.4",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0-rc.5",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -1344,13 +1633,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
  "hkdf",
  "pem-rfc7468 0.7.0",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1358,10 +1647,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "enum-assoc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "enum_dispatch"
@@ -1388,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1443,6 +1767,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -1504,7 +1834,7 @@ dependencies = [
  "ahash",
  "num_cpus",
  "parking_lot",
- "seize",
+ "seize 0.3.3",
 ]
 
 [[package]]
@@ -1572,6 +1902,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1946,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1649,6 +2005,21 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -1707,11 +2078,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1722,6 +2095,18 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1834,6 +2219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +2321,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,21 +2360,51 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.1"
+version = "0.26.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+checksum = "1e232f503c4cfe3f4ea6594971255ecab9f6a0080c4c8e0e17630cc701322aa4"
 dependencies = [
  "async-trait",
+ "bytes",
  "cfg-if",
  "data-encoding",
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto",
+ "h2",
+ "hickory-proto 0.26.0-beta.4",
+ "http",
  "idna",
  "ipnet",
  "jni 0.22.4",
  "rand 0.10.1",
+ "rustls",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
  "thiserror 2.0.17",
  "tinyvec",
  "tokio",
@@ -1976,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.1"
+version = "0.26.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+checksum = "fcca12171ce774c549f35510be702f4da00ef12ca486f0f2acb2ee96f2f5ca0f"
 dependencies = [
  "data-encoding",
  "idna",
@@ -1996,14 +2434,35 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto 0.25.2",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7d2c928fa078e6640f26cf1b537b212e1688829c3944780025c7084e8bbbf6"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto",
+ "hickory-proto 0.26.0-beta.4",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -2013,10 +2472,12 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "resolv-conf",
+ "rustls",
  "smallvec",
  "system-configuration",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -2035,7 +2496,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2103,6 +2564,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2180,7 +2650,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2286,6 +2756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "identity-hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2780,26 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581"
+dependencies = [
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.10.1",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -2383,7 +2879,7 @@ dependencies = [
  "argon2",
  "bcrypt-pbkdf",
  "ecdsa",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hex",
  "hmac",
  "num-bigint-dig",
@@ -2394,8 +2890,8 @@ dependencies = [
  "rsa",
  "sec1",
  "sha1",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "ssh-cipher",
  "ssh-encoding",
  "subtle",
@@ -2426,11 +2922,176 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "iroh"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9881b221c7c645d90594cbd331012f7cccb914894288a6cf5538a9115f6d0f3e"
+dependencies = [
+ "backon",
+ "blake3",
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "ctutils",
+ "data-encoding",
+ "der 0.8.0-rc.10",
+ "derive_more",
+ "ed25519-dalek 3.0.0-pre.6",
+ "futures-util",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.0-beta.4",
+ "http",
+ "ipnet",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "iroh-relay",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netwatch",
+ "noq",
+ "noq-proto",
+ "noq-udp",
+ "papaya",
+ "pin-project",
+ "pkcs8 0.11.0-rc.10",
+ "portable-atomic",
+ "portmapper",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "smallvec",
+ "strum 0.28.0",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "webpki-roots",
+]
+
+[[package]]
+name = "iroh-base"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738865784637830fb14204ebd3047922db83bc1816a59027af29579b9c27bd99"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "data-encoding",
+ "data-encoding-macro",
+ "derive_more",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0-pre.6",
+ "getrandom 0.4.2",
+ "n0-error",
+ "rand 0.10.1",
+ "serde",
+ "sha2 0.11.0-rc.5",
+ "url",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "iroh-dns"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca474630d1e62ddef83149db6babe6a1055d901df9054349d31b22df99811b92"
+dependencies = [
+ "derive_more",
+ "iroh-base",
+ "n0-error",
+ "n0-future",
+ "simple-dns",
+ "strum 0.28.0",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761b45ba046134b11eb3e432fa501616b45c4bf3a30c21717578bc07aa6461dd"
+dependencies = [
+ "iroh-metrics-derive",
+ "itoa",
+ "n0-error",
+ "portable-atomic",
+ "postcard",
+ "ryu",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab063c2bfd6c3d5a33a913d4fdb5252f140db29ec67c704f20f3da7e8f92dbf"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "iroh-relay"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa6e9a7277bfbb439739c52b57eb5f9288030983928412022b8e94a43d4d838"
+dependencies = [
+ "blake3",
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "data-encoding",
+ "derive_more",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.0-beta.4",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "lru",
+ "n0-error",
+ "n0-future",
+ "noq",
+ "noq-proto",
+ "num_enum",
+ "pin-project",
+ "postcard",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "url",
+ "vergen-gitcl",
+ "webpki-roots",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -2555,11 +3216,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2601,7 +3263,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2742,6 +3404,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +3445,8 @@ dependencies = [
  "filetime",
  "futures",
  "homedir",
+ "iroh",
+ "jsonwebtoken",
  "libc",
  "m87-shared",
  "nix 0.30.1",
@@ -2779,7 +3456,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "ratatui",
- "reqwest",
+ "reqwest 0.12.28",
  "rmcp",
  "russh",
  "russh-sftp",
@@ -2833,12 +3510,12 @@ dependencies = [
  "rand 0.8.6",
  "rand_core 0.6.4",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "socket2 0.6.1",
  "tokio",
  "tokio-rustls",
@@ -2857,9 +3534,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "uuid",
 ]
+
+[[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
 
 [[package]]
 name = "mac_address"
@@ -2950,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3074,9 +3757,9 @@ checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
 
 [[package]]
 name = "mongodb"
-version = "3.7.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
+checksum = "1ef2c933617431ad0246fb5b43c425ebdae18c7f7259c87de0726d93b0e7e91b"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.10.0",
@@ -3087,9 +3770,8 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
- "hickory-net",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-proto 0.25.2",
+ "hickory-resolver 0.25.2",
  "hmac",
  "macro_magic",
  "md-5",
@@ -3100,11 +3782,12 @@ dependencies = [
  "rand 0.9.2",
  "rustc_version_runtime",
  "rustls",
+ "rustversion",
  "serde",
  "serde_bytes",
  "serde_with",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "socket2 0.6.1",
  "stringprep",
  "strsim",
@@ -3131,10 +3814,181 @@ dependencies = [
 ]
 
 [[package]]
+name = "n0-error"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4782b4baf92d686d161c15460c83d16ebcfd215918763903e9619842665cae"
+dependencies = [
+ "n0-error-macros",
+ "spez",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "n0-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "derive_more",
+ "futures-buffered",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "n0-watcher"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38795f7932e6e9d1c6e989270ef5b3ff24ebb910e2c9d4bed2d28d8bae3007dc"
+dependencies = [
+ "derive_more",
+ "n0-error",
+ "n0-future",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "netdev"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e30af1a5073b82356d9317c18226826370b4288eba2f71c7e84e18bae51b3847"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "mac-addr",
+ "netlink-packet-core",
+ "netlink-packet-route 0.29.0",
+ "netlink-sys",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc0d4b4134425d9834e591b1a6f807ea365c6d941d738942215564af5f28a97"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "derive_more",
+ "js-sys",
+ "libc",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netdev",
+ "netlink-packet-core",
+ "netlink-packet-route 0.30.0",
+ "netlink-proto",
+ "netlink-sys",
+ "noq-udp",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "pin-project-lite",
+ "serde",
+ "socket2 0.6.1",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
+ "wmi",
+]
 
 [[package]]
 name = "nix"
@@ -3203,6 +4057,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "noq"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b969bd157c3bd3bab239a1a8b14f67f2033fa012770367fcbd5b42d71ae3548"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "derive_more",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdec6f5039d98ee5377b2f532d495a555eb664c53161b1b5780dcaeac678b60e"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more",
+ "enum-assoc",
+ "getrandom 0.4.2",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.10.1",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee91b05f4f3353290936ba1f3233518868fb4e2da99cb4c90d1f8cebb064e527"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,7 +4132,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3305,6 +4220,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,18 +4268,27 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
 ]
 
 [[package]]
@@ -3352,7 +4298,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-io-kit"
@@ -3362,6 +4318,31 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -3395,7 +4376,7 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "dyn-clone",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hmac",
  "http",
  "itertools 0.10.5",
@@ -3411,7 +4392,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_plain",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -3456,7 +4437,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3468,7 +4449,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3482,7 +4463,7 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3497,12 +4478,28 @@ dependencies = [
  "futures",
  "log",
  "rand 0.8.6",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "windows 0.62.2",
  "windows-strings 0.5.1",
 ]
+
+[[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize 0.5.1",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3539,6 +4536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,7 +4559,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -3634,7 +4637,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
 ]
 
 [[package]]
@@ -3690,6 +4703,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,9 +4740,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3720,11 +4753,11 @@ checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
  "aes",
  "cbc",
- "der",
+ "der 0.7.10",
  "pbkdf2",
  "scrypt",
- "sha2",
- "spki",
+ "sha2 0.10.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3733,10 +4766,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs5",
  "rand_core 0.6.4",
- "spki",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b226d2cc389763951db8869584fd800cbbe2962bf454e2edeb5172b31ee99774"
+dependencies = [
+ "der 0.8.0-rc.10",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3744,6 +4787,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.12.1",
+ "quick-xml 0.39.4",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "poly1305"
@@ -3773,6 +4829,9 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "portable-pty"
@@ -3793,6 +4852,61 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg 0.10.1",
+]
+
+[[package]]
+name = "portmapper"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a145e62ddd9aecc9c7b1a3c84cea2a803386c7f4da7795bf9f0d50d90dc52549"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "derive_more",
+ "futures-lite",
+ "futures-util",
+ "hyper-util",
+ "igd-next",
+ "iroh-metrics",
+ "libc",
+ "n0-error",
+ "netwatch",
+ "num_enum",
+ "rand 0.10.1",
+ "serde",
+ "smallvec",
+ "socket2 0.6.1",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3850,6 +4964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,6 +5023,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -3959,7 +5091,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4093,7 +5225,7 @@ dependencies = [
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.17",
  "unicode-segmentation",
  "unicode-truncate",
@@ -4156,7 +5288,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -4295,6 +5427,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,17 +5534,17 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4394,13 +5563,13 @@ dependencies = [
  "bytes",
  "cbc",
  "ctr",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "data-encoding",
  "delegate",
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "ecdsa",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "elliptic-curve",
  "enum_dispatch",
  "flate2",
@@ -4423,7 +5592,7 @@ dependencies = [
  "pbkdf2",
  "pkcs1",
  "pkcs5",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "rsa",
@@ -4431,9 +5600,9 @@ dependencies = [
  "russh-util",
  "sec1",
  "sha1",
- "sha2",
- "signature",
- "spki",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "ssh-encoding",
  "subtle",
  "thiserror 1.0.69",
@@ -4519,7 +5688,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4578,7 +5747,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4677,6 +5846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,7 +5865,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4700,9 +5875,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -4737,6 +5912,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "self-replace"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,9 +5943,9 @@ dependencies = [
  "hyper",
  "indicatif",
  "log",
- "quick-xml",
+ "quick-xml 0.37.5",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "self-replace",
  "semver",
  "serde_json",
@@ -4775,6 +5960,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -4964,8 +6155,14 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -4975,7 +6172,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5045,9 +6253,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -5070,6 +6284,15 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-dns"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+dependencies = [
+ "bitflags 2.10.0",
+]
 
 [[package]]
 name = "simple_asn1"
@@ -5122,10 +6345,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted-index-buffer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
+
+[[package]]
+name = "spez"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spinning_top"
@@ -5143,7 +6392,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-rc.10",
 ]
 
 [[package]]
@@ -5172,7 +6431,7 @@ dependencies = [
  "base64ct",
  "bytes",
  "pem-rfc7468 0.7.0",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5210,7 +6469,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5218,6 +6486,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5366,7 +6646,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5425,7 +6705,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -5499,6 +6779,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -5640,6 +6921,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5667,6 +6949,59 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.4.2",
+ "http",
+ "httparse",
+ "rand 0.10.1",
+ "ring",
+ "rustls-pki-types",
+ "sha1_smol",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db3bae107c9522f86d361697dee1d7386a2ddcf659d5aea5159819a21a3c4a7"
+dependencies = [
+ "indexmap 2.12.1",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -5722,9 +7057,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -5745,9 +7080,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5908,7 +7243,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -5986,6 +7321,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib 9.1.0",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib 0.1.6",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6045,9 +7428,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6058,22 +7441,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6081,9 +7461,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6094,9 +7474,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -6124,6 +7504,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6137,9 +7530,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6211,7 +7604,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -6293,7 +7686,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6799,6 +8192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6912,10 +8314,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "wmi"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.17",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wyz"
@@ -6934,6 +8370,21 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
 ]
 
 [[package]]
@@ -7069,7 +8520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,6 +3530,9 @@ dependencies = [
 name = "m87-shared"
 version = "0.0.0-dev0"
 dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek 2.2.0",
+ "getrandom 0.2.16",
  "hex",
  "serde",
  "serde_json",

--- a/deny.toml
+++ b/deny.toml
@@ -130,6 +130,35 @@ reason = "Transitive via self_update's S3 XML backend, which m87-client does not
 id = "RUSTSEC-2026-0195" # quick-xml: unbounded NsReader namespace-declaration allocation (mem DoS)
 reason = "Same transitive self_update path as RUSTSEC-2026-0194; m87-client uses the GitHub (JSON) update backend, not the S3 XML backend, so NsReader never parses untrusted XML. Blocked on self_update adopting quick-xml >=0.41."
 
+# --- paste: unmaintained, transitive via iroh's netlink stack ---
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0436" # paste unmaintained
+reason = "Build-time-only proc-macro (token pasting), pulled transitively via iroh -> netwatch -> netdev -> netlink-packet-core. No runtime or security impact — the crate is archived/unmaintained, not vulnerable, and the advisory notes no safe upgrade is available. Will clear when iroh's netlink dependency chain moves off paste."
+
+# --- atomic-polyfill: unmaintained, transitive via iroh ---
+[[advisories.ignore]]
+id = "RUSTSEC-2023-0089" # atomic-polyfill unmaintained
+reason = "Unmaintained (superseded by portable-atomic), pulled transitively via iroh. No known vulnerability and no safe upgrade available; the crate only provides atomic shims. Will clear when iroh's dependency chain moves off atomic-polyfill."
+
+# --- hickory (DNS) DoS advisories: iroh 0.98.2 exact-pins hickory 0.26.0-beta.4 ---
+# iroh uses hickory for its DNS-based node discovery. iroh 0.98.2 pins
+# `hickory-resolver = "=0.26.0-beta.4"` (exact), so there is NO upgrade path to
+# the fixed >=0.26.1 without bumping iroh itself (a breaking change tracked
+# separately). These are CPU/loop DoS bugs reachable only via malicious DNS
+# responses during discovery — no RCE or data exposure. Revisit as soon as iroh
+# ships a release that moves off the vulnerable hickory beta.
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0118" # hickory: NSEC3 closest-encloser proof — unbounded loop
+reason = "DoS-only (unbounded loop on crafted cross-zone DNSSEC responses) in hickory 0.26.0-beta.4, exact-pinned by iroh 0.98.2. No fix without an iroh bump. Only reachable via malicious DNS during iroh node discovery; no RCE/data impact. Will clear when iroh moves to hickory >=0.26.1."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0119" # hickory: O(n^2) name compression — CPU exhaustion on encode
+reason = "DoS-only (quadratic CPU during DNS message encoding) in hickory 0.26.0-beta.4, exact-pinned by iroh 0.98.2. No fix without an iroh bump. Reachable only on the iroh discovery DNS path; no RCE/data impact. Will clear when iroh moves to hickory >=0.26.1."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0120" # hickory: NSEC3 closest-encloser proof — unbounded loop
+reason = "DoS-only (unbounded loop on crafted cross-zone DNSSEC responses) in hickory 0.26.0-beta.4, exact-pinned by iroh 0.98.2. No fix without an iroh bump. Only reachable via malicious DNS during iroh node discovery; no RCE/data impact. Will clear when iroh moves to hickory >=0.26.1."
+
 
 [licenses]
 # List of explicitly allowed licenses

--- a/m87-client/Cargo.toml
+++ b/m87-client/Cargo.toml
@@ -64,6 +64,10 @@ termion = "4.0.6"
 ratatui = { version = "0.30", features = ["termion"] }
 # STUN client for public IP detection (WebRTC-compatible)
 stun = "0.9.0"
+iroh = "0.98"
+
+# Cryptography and auth
+jsonwebtoken = { workspace = true }
 
 bytes = ">=1.11.1"
 # ssh

--- a/m87-client/Dockerfile.e2e
+++ b/m87-client/Dockerfile.e2e
@@ -1,5 +1,31 @@
-# E2E test image - extends production image with Docker CLI
-FROM m87-client:latest
+# E2E-only image. Copies a host-built (native glibc) `m87` binary into a
+# glibc-matched base with the tools the e2e suite needs. NO cargo build happens
+# here — the binary is compiled once on the host (reusing the cargo `target/`
+# cache) and staged into this build context by
+# tests/src/e2e_containers/setup.rs, so this image builds in seconds.
+#
+# This one image backs both the CLI container and the runtime/agent container,
+# so it carries: docker CLI (for `m87 <dev> docker` proxy tests), netcat-openbsd
+# (`nc`, for the UDP-forward test), and curl.
+#
+# NOT used for production — see m87-client/Dockerfile for the static musl ->
+# alpine build. ubuntu:24.04 matches the glibc of the GitHub runner that
+# compiles the binary (glibc is backward- but not forward-compatible).
+FROM ubuntu:24.04
 
-# Install Docker CLI for e2e testing
-RUN apk add --no-cache docker-cli
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        netcat-openbsd \
+        docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Binary is staged next to this Dockerfile by setup.rs (build context = temp dir).
+COPY m87 /app/m87
+
+ENV PATH="/app:${PATH}"
+
+ENTRYPOINT ["/app/m87"]

--- a/m87-client/Dockerfile.install-test
+++ b/m87-client/Dockerfile.install-test
@@ -1,7 +1,11 @@
 # Minimal container for testing install.sh
 # No pre-installed m87 binary - clean environment for install testing
-
-FROM debian:bookworm-slim
+#
+# ubuntu:24.04 (glibc 2.39) matches the glibc the e2e `m87` binary is built
+# against on the GitHub runner — install.sh installs and then RUNS that binary,
+# so the base must be glibc >= the build host. (Was debian:bookworm-slim / 2.36,
+# which only worked because the old extracted binary was a static musl build.)
+FROM ubuntu:24.04
 
 # Install dependencies needed by install.sh and for testing
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/m87-client/src/device/control_tunnel.rs
+++ b/m87-client/src/device/control_tunnel.rs
@@ -49,6 +49,36 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
     );
     debug!("Connecting QUIC control tunnel to {}", control_host);
 
+    // ── iroh P2P endpoint ────────────────────────────────────────────────────────
+    use crate::streams::iroh_p2p::IROH_ALPN;
+    use iroh::endpoint::presets;
+    use std::time::Duration as StdDuration;
+
+    let iroh_ep = {
+        match iroh::Endpoint::builder(presets::N0)
+            .alpns(vec![IROH_ALPN.to_vec()])
+            .bind()
+            .await
+        {
+            Ok(ep) => {
+                // Give it up to 10 s to register with its relay (best-effort)
+                tokio::time::timeout(StdDuration::from_secs(10), ep.online())
+                    .await
+                    .ok();
+                debug!("iroh endpoint bound, addr: {:?}", ep.addr());
+                Some(ep)
+            }
+            Err(e) => {
+                warn!("iroh: could not bind endpoint, P2P disabled: {e}");
+                None
+            }
+        }
+    };
+
+    let iroh_node_addr_json: Option<String> = iroh_ep
+        .as_ref()
+        .and_then(|ep| serde_json::to_string(&ep.addr()).ok());
+
     let (_endpoint, quic_conn): (_, Connection) =
         get_quic_connection(&control_host, &token, config.trust_invalid_server_cert)
             .await
@@ -165,8 +195,10 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
 
     let mut shutdown = shutdown_rx.clone();
 
+    let iroh_node_addr_for_sender = iroh_node_addr_json.clone();
     let _sender = tokio::spawn({
         let state = state.clone();
+        let iroh_node_addr = iroh_node_addr_for_sender;
         async move {
             loop {
                 use std::time::Duration;
@@ -192,6 +224,7 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
                                 last_instruction_hash: st.last_instruction_hash.clone(),
                                 deploy_report: Some(claimed.report.clone()),
                                 supported_revision_format: Some(2),
+                                iroh_node_addr: iroh_node_addr.clone(),
                                 ..Default::default()
                             }
                         };
@@ -220,6 +253,7 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
                             let mut req = HeartbeatRequest {
                                 last_instruction_hash: st.last_instruction_hash.clone(),
                                 supported_revision_format: Some(2),
+                                iroh_node_addr: iroh_node_addr.clone(),
                                 ..Default::default()
                             };
 
@@ -314,6 +348,46 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
         });
     }
 
+    // ── iroh P2P accept loop ──────────────────────────────────────────────────────────
+    if let Some(iroh_ep) = iroh_ep {
+        let unit_manager_iroh = unit_manager.clone();
+        let udp_channels_iroh = udp_channels.clone();
+        let datagram_tx_iroh = datagram_tx.clone();
+        let mut iroh_shutdown = shutdown_rx.clone();
+        let iroh_ep_clone = iroh_ep.clone();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = iroh_shutdown.changed() => {
+                        debug!("iroh accept loop: shutdown signal");
+                        break;
+                    }
+                    incoming = iroh_ep_clone.accept() => {
+                        let Some(incoming) = incoming else {
+                            debug!("iroh endpoint closed");
+                            break;
+                        };
+                        let unit_manager = unit_manager_iroh.clone();
+                        let udp_channels = udp_channels_iroh.clone();
+                        let datagram_tx = datagram_tx_iroh.clone();
+                        tokio::spawn(async move {
+                            let conn = match incoming.await {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    warn!("iroh: incoming connection handshake failed: {e}");
+                                    return;
+                                }
+                            };
+                            handle_iroh_connection(conn, unit_manager, udp_channels, datagram_tx).await;
+                        });
+                    }
+                }
+            }
+            iroh_ep_clone.close().await;
+        });
+    }
+
     let mut shutdown = shutdown_rx.clone();
     //  CONTROL STREAM ACCEPT LOOP
     loop {
@@ -330,7 +404,7 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
                     Ok((send, recv)) => {
                         debug!("QUIC: new control stream accepted");
 
-                        let io = QuicIo { recv, send };
+                        let io = QuicIo::from_quinn(recv, send);
                         let udp_channels_clone = udp_channels.clone();
                         let datagram_tx_clone = datagram_tx.clone();
                         let unit_manager_clone = unit_manager.clone();
@@ -391,4 +465,88 @@ pub async fn read_msg<T: DeserializeOwned>(io: &mut quinn::RecvStream) -> Result
     let msg: T = serde_json::from_slice::<T>(&buf)?;
 
     Ok(msg)
+}
+
+#[cfg(feature = "runtime")]
+async fn handle_iroh_connection(
+    conn: iroh::endpoint::Connection,
+    unit_manager: Arc<DeploymentManager>,
+    udp_channels: crate::streams::udp_manager::UdpChannelManager,
+    datagram_tx: tokio::sync::mpsc::Sender<(u32, bytes::Bytes)>,
+) {
+    use crate::streams::{self, quic::QuicIo};
+
+    // Authenticate: read token from first uni-directional stream
+    let token =
+        {
+            let mut recv =
+                match tokio::time::timeout(std::time::Duration::from_secs(5), conn.accept_uni())
+                    .await
+                {
+                    Ok(Ok(r)) => r,
+                    _ => {
+                        warn!("iroh: auth stream missing or timed out");
+                        return;
+                    }
+                };
+
+            let mut len_buf = [0u8; 2];
+            if recv.read_exact(&mut len_buf).await.is_err() {
+                warn!("iroh: failed to read token length");
+                return;
+            }
+            let len = u16::from_be_bytes(len_buf) as usize;
+            if len == 0 || len > 4096 {
+                warn!("iroh: invalid token length {len}");
+                return;
+            }
+            let mut buf = vec![0u8; len];
+            if recv.read_exact(&mut buf).await.is_err() {
+                warn!("iroh: failed to read token");
+                return;
+            }
+            match String::from_utf8(buf) {
+                Ok(t) => t,
+                Err(_) => {
+                    warn!("iroh: token not valid utf-8");
+                    return;
+                }
+            }
+        };
+
+    // Validate token (Auth0 JWKS check)
+    if let Err(e) = crate::streams::auth::validate_token(&token).await {
+        warn!("iroh: token validation failed: {e}");
+        return;
+    }
+
+    debug!("iroh: connection authenticated");
+
+    // Accept bi-directional streams and route them
+    loop {
+        match conn.accept_bi().await {
+            Ok((send, recv)) => {
+                let io = QuicIo::from_iroh(recv, send);
+                let unit_manager = unit_manager.clone();
+                let udp_channels = udp_channels.clone();
+                let datagram_tx = datagram_tx.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = streams::router::handle_incoming_stream(
+                        io,
+                        udp_channels,
+                        datagram_tx,
+                        unit_manager,
+                    )
+                    .await
+                    {
+                        warn!("iroh: stream handler error: {e}");
+                    }
+                });
+            }
+            Err(e) => {
+                debug!("iroh: connection closed: {e}");
+                break;
+            }
+        }
+    }
 }

--- a/m87-client/src/device/control_tunnel.rs
+++ b/m87-client/src/device/control_tunnel.rs
@@ -112,9 +112,16 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
         first_heartbeat: true,
     }));
 
+    // Server's iroh ticket-signing public key (base64), learned from heartbeat
+    // responses. The iroh accept loop verifies CLI connection tickets against
+    // it. None until the first heartbeat response carrying it arrives.
+    let server_ticket_pubkey: Arc<tokio::sync::RwLock<Option<String>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
+
     let manager_clone = unit_manager.clone();
     let _receiver = tokio::spawn({
         let state = state.clone();
+        let server_ticket_pubkey = server_ticket_pubkey.clone();
         use crate::device::deployment_manager::ack_event;
         async move {
             loop {
@@ -124,6 +131,15 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
                     msg = read_msg::<HeartbeatResponse>(&mut recv) => {
                         let resp = msg?;
                         tracing::debug!("Received heartbeat response");
+
+                        // Cache the server's ticket-signing public key for the
+                        // iroh accept loop to verify direct-connection tickets.
+                        if let Some(pk) = resp.iroh_ticket_pubkey.as_deref() {
+                            let mut guard = server_ticket_pubkey.write().await;
+                            if guard.as_deref() != Some(pk) {
+                                *guard = Some(pk.to_string());
+                            }
+                        }
 
                         // Don't hold `state` across `set_desired_units` /
                         // `apply_lifecycle_updates` / `ack_event` — those can
@@ -352,9 +368,10 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
     if let Some(iroh_ep) = iroh_ep {
         let unit_manager_iroh = unit_manager.clone();
         let udp_channels_iroh = udp_channels.clone();
-        let datagram_tx_iroh = datagram_tx.clone();
         let mut iroh_shutdown = shutdown_rx.clone();
         let iroh_ep_clone = iroh_ep.clone();
+        let iroh_short_id = short_id.to_string();
+        let iroh_pubkey = server_ticket_pubkey.clone();
 
         tokio::spawn(async move {
             loop {
@@ -370,7 +387,8 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
                         };
                         let unit_manager = unit_manager_iroh.clone();
                         let udp_channels = udp_channels_iroh.clone();
-                        let datagram_tx = datagram_tx_iroh.clone();
+                        let short_id = iroh_short_id.clone();
+                        let pubkey = iroh_pubkey.clone();
                         tokio::spawn(async move {
                             let conn = match incoming.await {
                                 Ok(c) => c,
@@ -379,7 +397,10 @@ pub async fn connect_control_tunnel(unit_manager: Arc<DeploymentManager>) -> Res
                                     return;
                                 }
                             };
-                            handle_iroh_connection(conn, unit_manager, udp_channels, datagram_tx).await;
+                            handle_iroh_connection(
+                                conn, unit_manager, udp_channels, short_id, pubkey,
+                            )
+                            .await;
                         });
                     }
                 }
@@ -472,64 +493,140 @@ async fn handle_iroh_connection(
     conn: iroh::endpoint::Connection,
     unit_manager: Arc<DeploymentManager>,
     udp_channels: crate::streams::udp_manager::UdpChannelManager,
-    datagram_tx: tokio::sync::mpsc::Sender<(u32, bytes::Bytes)>,
+    device_short_id: String,
+    server_ticket_pubkey: Arc<tokio::sync::RwLock<Option<String>>>,
 ) {
+    use bytes::{BufMut, Bytes, BytesMut};
+
     use crate::streams::{self, quic::QuicIo};
 
-    // Authenticate: read token from first uni-directional stream
-    let token =
-        {
-            let mut recv =
-                match tokio::time::timeout(std::time::Duration::from_secs(5), conn.accept_uni())
-                    .await
-                {
-                    Ok(Ok(r)) => r,
-                    _ => {
-                        warn!("iroh: auth stream missing or timed out");
-                        return;
-                    }
-                };
-
-            let mut len_buf = [0u8; 2];
-            if recv.read_exact(&mut len_buf).await.is_err() {
-                warn!("iroh: failed to read token length");
-                return;
-            }
-            let len = u16::from_be_bytes(len_buf) as usize;
-            if len == 0 || len > 4096 {
-                warn!("iroh: invalid token length {len}");
-                return;
-            }
-            let mut buf = vec![0u8; len];
-            if recv.read_exact(&mut buf).await.is_err() {
-                warn!("iroh: failed to read token");
-                return;
-            }
-            match String::from_utf8(buf) {
-                Ok(t) => t,
-                Err(_) => {
-                    warn!("iroh: token not valid utf-8");
+    // Authenticate: the CLI opens a uni-stream and sends a server-signed
+    // connection ticket. We verify the *server's* signature — we already trust
+    // the server — rather than re-checking the CLI's own credentials. This is
+    // what lets any caller the server accepts (OAuth users and API keys) use a
+    // direct connection.
+    let signed_ticket: m87_shared::iroh_ticket::SignedIrohTicket = {
+        let mut recv =
+            match tokio::time::timeout(std::time::Duration::from_secs(5), conn.accept_uni()).await {
+                Ok(Ok(r)) => r,
+                _ => {
+                    warn!("iroh: auth stream missing or timed out");
                     return;
                 }
-            }
-        };
+            };
 
-    // Validate token (Auth0 JWKS check)
-    if let Err(e) = crate::streams::auth::validate_token(&token).await {
-        warn!("iroh: token validation failed: {e}");
+        let mut len_buf = [0u8; 2];
+        if recv.read_exact(&mut len_buf).await.is_err() {
+            warn!("iroh: failed to read ticket length");
+            return;
+        }
+        let len = u16::from_be_bytes(len_buf) as usize;
+        if len == 0 || len > 8192 {
+            warn!("iroh: invalid ticket length {len}");
+            return;
+        }
+        let mut buf = vec![0u8; len];
+        if recv.read_exact(&mut buf).await.is_err() {
+            warn!("iroh: failed to read ticket");
+            return;
+        }
+        match serde_json::from_slice(&buf) {
+            Ok(t) => t,
+            Err(e) => {
+                warn!("iroh: ticket not valid JSON: {e}");
+                return;
+            }
+        }
+    };
+
+    // Verify the ticket against the server's advertised signing key.
+    let Some(pubkey_b64) = server_ticket_pubkey.read().await.clone() else {
+        warn!("iroh: no server ticket key known yet — rejecting connection");
         return;
+    };
+    let verifying_key = match m87_shared::iroh_ticket::verifying_key_from_b64(&pubkey_b64) {
+        Ok(k) => k,
+        Err(e) => {
+            warn!("iroh: bad server ticket key: {e}");
+            return;
+        }
+    };
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    match signed_ticket.verify(&verifying_key, &device_short_id, now_ms) {
+        Ok(ticket) => {
+            debug!("iroh: connection authorized for subject '{}'", ticket.subject)
+        }
+        Err(e) => {
+            warn!("iroh: ticket rejected: {e}");
+            return;
+        }
     }
 
-    debug!("iroh: connection authenticated");
+    // Per-connection UDP datagram plumbing. The relay multiplexes every
+    // device's datagrams over one tunnel, but each iroh connection carries its
+    // own — so egress must go back over *this* connection, not the relay.
+    let (iroh_dgram_tx, mut iroh_dgram_rx) =
+        tokio::sync::mpsc::channel::<(u32, bytes::Bytes)>(2048);
 
-    // Accept bi-directional streams and route them
+    // Egress: device → CLI. Frame `[channel_id][payload]` and send as a datagram.
+    {
+        let conn = conn.clone();
+        tokio::spawn(async move {
+            while let Some((id, payload)) = iroh_dgram_rx.recv().await {
+                let mut buf = BytesMut::with_capacity(4 + payload.len());
+                buf.put_u32(id);
+                buf.extend_from_slice(&payload);
+                if conn.send_datagram(buf.freeze()).is_err() {
+                    break;
+                }
+            }
+        });
+    }
+
+    // Ingress: CLI → device. Route each datagram to its channel by id.
+    {
+        let conn = conn.clone();
+        let udp_channels = udp_channels.clone();
+        tokio::spawn(async move {
+            loop {
+                match conn.read_datagram().await {
+                    Ok(d) => {
+                        if d.len() < 4 {
+                            continue;
+                        }
+                        let id = u32::from_be_bytes([d[0], d[1], d[2], d[3]]);
+                        let payload = Bytes::copy_from_slice(&d[4..]);
+                        match udp_channels.get(id).await {
+                            Some(ch) => {
+                                debug!("iroh ingress: datagram id={id} len={} → channel", payload.len());
+                                let _ = ch.sender.try_send(payload);
+                            }
+                            None => {
+                                debug!("iroh ingress: datagram id={id} has no channel — dropping");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        debug!("iroh ingress: read_datagram ended: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    // Accept bi-directional streams and route them. UDP forward streams get
+    // this connection's datagram sender so their responses go back over iroh.
     loop {
         match conn.accept_bi().await {
             Ok((send, recv)) => {
                 let io = QuicIo::from_iroh(recv, send);
                 let unit_manager = unit_manager.clone();
                 let udp_channels = udp_channels.clone();
-                let datagram_tx = datagram_tx.clone();
+                let datagram_tx = iroh_dgram_tx.clone();
                 tokio::spawn(async move {
                     if let Err(e) = streams::router::handle_incoming_stream(
                         io,

--- a/m87-client/src/device/forward.rs
+++ b/m87-client/src/device/forward.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use bytes::BufMut;
 use bytes::BytesMut;
 use tokio::io;
+use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use tokio::net::UdpSocket;
 use tokio::net::UnixListener;
@@ -47,8 +48,15 @@ pub async fn start_forward(
         let resolved = resolved.clone();
         let cancel = cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) =
-                forward_device_port(&resolved.host, &token, &resolved.short_id, t, trust, cancel.clone()).await
+            if let Err(e) = forward_device_port(
+                &resolved.host,
+                &token,
+                &resolved.short_id,
+                t,
+                trust,
+                cancel.clone(),
+            )
+            .await
             {
                 error!("Forward exited with error: {}", e);
                 cancel.cancel();

--- a/m87-client/src/device/forward.rs
+++ b/m87-client/src/device/forward.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::devices;
-use crate::streams::quic::connect_quic_only;
-use crate::streams::quic::open_quic_stream;
+use crate::streams::quic::DeviceConnection;
+use crate::streams::quic::connect_device;
 use crate::streams::stream_type::{ForwardTarget, SocketTarget, TcpTarget, UdpTarget};
 use crate::util::shutdown::SHUTDOWN;
 use crate::util::udp::decode_socket_addr;
@@ -50,8 +50,10 @@ pub async fn start_forward(
         tokio::spawn(async move {
             if let Err(e) = forward_device_port(
                 &resolved.host,
+                &resolved.url,
                 &token,
                 &resolved.short_id,
+                &resolved.id,
                 t,
                 trust,
                 cancel.clone(),
@@ -69,8 +71,10 @@ pub async fn start_forward(
 
 pub async fn forward_device_port(
     host_name: &str,
+    server_url: &str,
     token: &str,
     device_short_id: &str,
+    device_object_id: &str,
     forward_target: ForwardTarget,
     trust_invalid_server_cert: bool,
     cancel: CancellationToken,
@@ -79,8 +83,10 @@ pub async fn forward_device_port(
         ForwardTarget::Tcp(target) => {
             forward_device_port_tcp(
                 host_name,
+                server_url,
                 token,
                 device_short_id,
+                device_object_id,
                 target,
                 trust_invalid_server_cert,
                 cancel,
@@ -90,8 +96,10 @@ pub async fn forward_device_port(
         ForwardTarget::Udp(target) => {
             forward_device_port_udp(
                 host_name,
+                server_url,
                 token,
                 device_short_id,
+                device_object_id,
                 target,
                 trust_invalid_server_cert,
                 cancel,
@@ -101,8 +109,10 @@ pub async fn forward_device_port(
         ForwardTarget::Socket(target) => {
             forward_device_socket(
                 host_name,
+                server_url,
                 token,
                 device_short_id,
+                device_object_id,
                 target,
                 trust_invalid_server_cert,
                 cancel,
@@ -118,8 +128,10 @@ pub async fn forward_device_port(
 
 async fn forward_device_port_tcp(
     host_name: &str,
+    server_url: &str,
     token: &str,
     device_short_id: &str,
+    device_object_id: &str,
     forward_spec: &TcpTarget,
     trust_invalid_server_cert: bool,
     cancel: CancellationToken,
@@ -131,14 +143,25 @@ async fn forward_device_port_tcp(
     let listener = TcpListener::bind(("127.0.0.1", forward_spec.local_port)).await?;
     let remote_host = forward_spec.remote_host.clone();
 
-    debug!("Connecting to QUIC server...");
-    let (_endpoint, conn) =
-        connect_quic_only(host_name, token, device_short_id, trust_invalid_server_cert).await?;
-    debug!("QUIC connection established, entering accept loop");
+    debug!("Connecting to device (iroh-preferred)...");
+    let conn = connect_device(
+        host_name,
+        server_url,
+        device_short_id,
+        device_object_id,
+        token,
+        trust_invalid_server_cert,
+    )
+    .await?;
+    debug!("Connection established via {}, entering accept loop", conn.transport());
 
     println!(
-        "TCP forward: 127.0.0.1:{} → {}/{}:{}",
-        &forward_spec.local_port, device_short_id, remote_host, &forward_spec.remote_port
+        "TCP forward: 127.0.0.1:{} → {}/{}:{} ({})",
+        &forward_spec.local_port,
+        device_short_id,
+        remote_host,
+        &forward_spec.remote_port,
+        conn.transport()
     );
     loop {
         tokio::select! {
@@ -146,10 +169,7 @@ async fn forward_device_port_tcp(
                 let (mut local_stream, addr) = accept_result?;
                 info!("New local TCP connection from {addr}");
                 let stream_type = forward_spec.to_stream_type(token);
-                let mut quic_io = open_quic_stream(
-                    &conn,
-                    stream_type,
-                ).await?;
+                let mut quic_io = conn.open_stream(stream_type).await?;
 
                 tokio::spawn(async move {
                     let res = io::copy_bidirectional(&mut local_stream, &mut quic_io).await;
@@ -162,10 +182,7 @@ async fn forward_device_port_tcp(
                 });
             }
             reason = conn.closed() => {
-                warn!("Connection closed: {:?}", reason);
-                if let Some(close_reason) = conn.close_reason() {
-                    warn!("Close reason: {:?}", close_reason);
-                }
+                warn!("Connection closed: {reason}");
                 break;
             }
 
@@ -181,18 +198,29 @@ async fn forward_device_port_tcp(
 
 async fn forward_device_port_udp(
     host_name: &str,
+    server_url: &str,
     token: &str,
     device_short_id: &str,
+    device_object_id: &str,
     forward_spec: &UdpTarget,
     trust_invalid_server_cert: bool,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let (_endpoint, conn) =
-        connect_quic_only(host_name, token, device_short_id, trust_invalid_server_cert).await?;
+    let conn = Arc::new(
+        connect_device(
+            host_name,
+            server_url,
+            device_short_id,
+            device_object_id,
+            token,
+            trust_invalid_server_cert,
+        )
+        .await?,
+    );
 
-    // Send StreamType::Forward over a QUIC stream
+    // Open the control stream to obtain the channel id from the runtime.
     let stream_type = forward_spec.to_stream_type(token);
-    let mut quic_io = open_quic_stream(&conn, stream_type).await?;
+    let mut quic_io = conn.open_stream(stream_type).await?;
 
     // === Read channel_id assigned by the runtime ===
     let mut id_buf = [0u8; 4];
@@ -205,21 +233,22 @@ async fn forward_device_port_udp(
     quic_io.send.finish()?;
 
     println!(
-        "UDP forward: 127.0.0.1:{} → {} {}:{}",
+        "UDP forward: 127.0.0.1:{} → {} {}:{} ({})",
         &forward_spec.local_port,
         device_short_id,
         &forward_spec.remote_host,
-        &forward_spec.remote_port
+        &forward_spec.remote_port,
+        conn.transport()
     );
 
-    // Now switch to datagram forwarding
-    udp_local_datagram_forward(forward_spec.local_port, channel_id, conn.clone(), cancel).await
+    // Now switch to datagram forwarding over the chosen transport.
+    udp_local_datagram_forward(forward_spec.local_port, channel_id, conn, cancel).await
 }
 
 pub async fn udp_local_datagram_forward(
     local_port: u16,
     channel_id: u32,
-    conn: quinn::Connection,
+    conn: Arc<DeviceConnection>,
     cancel: CancellationToken,
 ) -> Result<()> {
     let sock = Arc::new(UdpSocket::bind(("0.0.0.0", local_port)).await?);
@@ -302,7 +331,7 @@ pub async fn udp_local_datagram_forward(
     let conn_cl2 = conn.clone();
     tokio::select! {
         _ = conn_cl2.closed() => {
-            warn!("CLI QUIC connection closed — stopping UDP forward");
+            warn!("CLI connection closed — stopping UDP forward");
         }
 
         _ = udp_to_quic => {}
@@ -310,7 +339,7 @@ pub async fn udp_local_datagram_forward(
 
         _ = cancel.cancelled() => {
             info!("CLI shutdown requested — closing UDP forward");
-            let _ = conn.close(0u32.into(), b"shutdown");
+            conn.close(b"shutdown");
         }
     }
 
@@ -319,8 +348,10 @@ pub async fn udp_local_datagram_forward(
 
 async fn forward_device_socket(
     host_name: &str,
+    server_url: &str,
     token: &str,
     device_short_id: &str,
+    device_object_id: &str,
     target: &SocketTarget,
     trust_invalid_server_cert: bool,
     cancel: CancellationToken,
@@ -333,13 +364,23 @@ async fn forward_device_socket(
     }
 
     let listener = UnixListener::bind(local_path)?;
-    println!(
-        "Socket forward: local {} → {} {}",
-        local_path, device_short_id, target.remote_path
-    );
 
-    let (_endpoint, conn) =
-        connect_quic_only(host_name, token, device_short_id, trust_invalid_server_cert).await?;
+    let conn = connect_device(
+        host_name,
+        server_url,
+        device_short_id,
+        device_object_id,
+        token,
+        trust_invalid_server_cert,
+    )
+    .await?;
+    println!(
+        "Socket forward: local {} → {} {} ({})",
+        local_path,
+        device_short_id,
+        target.remote_path,
+        conn.transport()
+    );
 
     loop {
         tokio::select! {
@@ -347,7 +388,7 @@ async fn forward_device_socket(
                 info!("New UNIX socket connection: {}", local_path);
 
                 let stream_type = target.to_stream_type(token);
-                let mut quic_io = open_quic_stream(&conn, stream_type).await?;
+                let mut quic_io = conn.open_stream(stream_type).await?;
 
                 tokio::spawn(async move {
                     let res = io::copy_bidirectional(&mut local_stream, &mut quic_io).await;
@@ -361,7 +402,7 @@ async fn forward_device_socket(
             }
 
             reason = conn.closed() => {
-                warn!("Connection closed: {:?}", reason);
+                warn!("Connection closed: {reason}");
                 break;
             }
 

--- a/m87-client/src/device/fs.rs
+++ b/m87-client/src/device/fs.rs
@@ -16,6 +16,9 @@ use russh::client::{Config as ClientConfig, Handler};
 use russh_sftp::client::SftpSession;
 
 use crate::devices;
+// SFTP keeps the stream inside a long-lived russh session that outlives this
+// module's functions, so it stays on the always-available relay path rather
+// than the iroh connection (whose endpoint must be held alive by the caller).
 use crate::streams::quic::open_quic_io;
 use crate::streams::stream_type::StreamType;
 use crate::util::shutdown::SHUTDOWN;

--- a/m87-client/src/device/serial.rs
+++ b/m87-client/src/device/serial.rs
@@ -5,7 +5,7 @@ use std::os::fd::{FromRawFd, RawFd};
 use tokio::io::split;
 use tokio::task;
 
-use crate::streams::quic::open_quic_io;
+use crate::streams::quic::open_device_io;
 use crate::streams::stream_type::StreamType;
 use crate::{auth::AuthManager, config::Config, devices, util::shutdown::SHUTDOWN};
 
@@ -46,10 +46,12 @@ pub async fn open_serial(device: &str, port: &str, baud: u32) -> Result<()> {
         baud: Some(baud),
         name: port.to_string(),
     };
-    let (_, remote_io) = open_quic_io(
+    let (_conn, remote_io) = open_device_io(
         &resolved.host,
+        &resolved.url,
         &token,
         &resolved.short_id,
+        &resolved.id,
         stream_type,
         cfg.trust_invalid_server_cert,
     )

--- a/m87-client/src/device/ssh.rs
+++ b/m87-client/src/device/ssh.rs
@@ -9,7 +9,7 @@ use crate::{
     auth::AuthManager,
     config::Config,
     devices,
-    streams::{quic::open_quic_io, stream_type::StreamType},
+    streams::{quic::open_device_io, stream_type::StreamType},
     util::command::current_exe_path,
 };
 
@@ -21,10 +21,12 @@ pub async fn connect_device_ssh(device_name: &str) -> Result<()> {
 
     let token = AuthManager::get_cli_token().await?;
 
-    let (conn, mut quic) = open_quic_io(
+    let (conn, mut quic) = open_device_io(
         &resolved.host,
+        &resolved.url,
         &token,
         &resolved.short_id,
+        &resolved.id,
         StreamType::Ssh {
             token: token.to_string(),
         },

--- a/m87-client/src/streams/iroh_p2p.rs
+++ b/m87-client/src/streams/iroh_p2p.rs
@@ -1,0 +1,314 @@
+//! iroh-based direct P2P connections.
+//!
+//! The CLI tries a direct iroh connection to the device before falling back to
+//! the server relay path. The device advertises its iroh [`EndpointAddr`] via
+//! the heartbeat; the server caches it and exposes it via
+//! `GET /device/{id}/iroh-addr`.
+
+use anyhow::{Context, Result};
+use iroh::endpoint::Connection as IrohConnection;
+use iroh::{Endpoint as IrohEndpoint, EndpointAddr};
+use serde::Deserialize;
+use std::time::Duration;
+use tracing::{debug, warn};
+
+use crate::streams::quic::QuicIo;
+use crate::streams::stream_type::StreamType;
+
+/// ALPN used for direct iroh P2P connections between CLI and device.
+pub const IROH_ALPN: &[u8] = b"m87-iroh-p2p/1";
+
+/// Timeout when attempting an iroh P2P connection.
+const IROH_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Response body from `GET /device/{id}/iroh-addr`.
+#[derive(Deserialize)]
+struct IrohAddrResponse {
+    iroh_node_addr: String,
+}
+
+/// Fetch the iroh [`EndpointAddr`] for a device from the m87 server.
+///
+/// `server_url` is the HTTPS base URL, `token` is the user bearer token,
+/// `device_id` is the MongoDB ObjectId string of the device.
+pub async fn fetch_device_iroh_addr(
+    server_url: &str,
+    token: &str,
+    device_id: &str,
+) -> Result<EndpointAddr> {
+    let url = format!(
+        "{}/device/{}/iroh-addr",
+        server_url.trim_end_matches('/'),
+        device_id
+    );
+
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .bearer_auth(token)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .context("fetching iroh addr from server")?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!("server returned {} for iroh-addr", resp.status());
+    }
+
+    let body: IrohAddrResponse = resp.json().await.context("parsing iroh addr response")?;
+
+    let addr: EndpointAddr =
+        serde_json::from_str(&body.iroh_node_addr).context("deserializing iroh EndpointAddr")?;
+
+    Ok(addr)
+}
+
+/// Create an ephemeral iroh endpoint for the CLI (no ALPNs needed — we are
+/// the dialling side only).
+pub async fn create_cli_iroh_endpoint() -> Result<IrohEndpoint> {
+    IrohEndpoint::bind(iroh::endpoint::presets::N0)
+        .await
+        .context("binding CLI iroh endpoint")
+}
+
+/// Try to establish a direct iroh connection to the device.
+///
+/// Returns the iroh `Connection` on success.
+pub async fn try_iroh_connect(
+    ep: &IrohEndpoint,
+    device_addr: EndpointAddr,
+) -> Result<IrohConnection> {
+    debug!("iroh: attempting direct P2P connection");
+
+    let conn = tokio::time::timeout(IROH_CONNECT_TIMEOUT, ep.connect(device_addr, IROH_ALPN))
+        .await
+        .map_err(|_| anyhow::anyhow!("iroh connection timed out after {:?}", IROH_CONNECT_TIMEOUT))?
+        .context("iroh connect failed")?;
+
+    debug!("iroh: direct connection established");
+    Ok(conn)
+}
+
+/// Open an iroh bi-directional stream and send the stream-type header.
+/// Analogous to `open_quic_stream` in `quic.rs`.
+pub async fn open_iroh_stream(conn: &IrohConnection, stream_type: StreamType) -> Result<QuicIo> {
+    use tokio::io::AsyncWriteExt;
+    debug!("iroh: opening stream");
+    let (mut send, recv) = conn.open_bi().await.context("iroh open_bi")?;
+
+    let json = serde_json::to_vec(&stream_type)?;
+    let len = (json.len() as u32).to_be_bytes();
+
+    send.write_all(&len).await?;
+    send.write_all(&json).await?;
+    send.flush().await?;
+
+    debug!("iroh: stream opened");
+    Ok(QuicIo::from_iroh(recv, send))
+}
+
+/// High-level helper: fetch iroh addr from server, try direct connection,
+/// open stream. Returns `None` if anything fails (caller falls back to relay).
+pub async fn try_open_iroh_stream(
+    server_url: &str,
+    token: &str,
+    device_id: &str,
+    stream_type: StreamType,
+) -> Option<(IrohConnection, QuicIo)> {
+    let addr = match fetch_device_iroh_addr(server_url, token, device_id).await {
+        Ok(a) => a,
+        Err(e) => {
+            debug!("iroh: could not get device addr: {e}");
+            return None;
+        }
+    };
+
+    let ep = match create_cli_iroh_endpoint().await {
+        Ok(e) => e,
+        Err(e) => {
+            warn!("iroh: could not create endpoint: {e}");
+            return None;
+        }
+    };
+
+    let conn = match try_iroh_connect(&ep, addr).await {
+        Ok(c) => c,
+        Err(e) => {
+            debug!("iroh: direct connect failed (will use relay): {e}");
+            return None;
+        }
+    };
+
+    match open_iroh_stream(&conn, stream_type).await {
+        Ok(io) => Some((conn, io)),
+        Err(e) => {
+            warn!("iroh: stream open failed: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // ── constants ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_iroh_alpn_is_correct() {
+        assert_eq!(IROH_ALPN, b"m87-iroh-p2p/1");
+        assert!(!IROH_ALPN.is_empty());
+    }
+
+    // ── QuicIo enum delegation ───────────────────────────────────────
+
+    /// Verify that QuicIo::from_iroh + AsyncWrite/AsyncRead delegation works
+    /// over a real in-process iroh connection between two local endpoints.
+    /// This is the core wiring test for the new transport path.
+    ///
+    /// NOTE: requires a loopback network interface and a live internet
+    /// connection is NOT needed — iroh discovers both endpoints on the same
+    /// machine via direct UDP addresses before contacting any relay.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_quic_io_from_iroh_roundtrip() {
+        use crate::streams::quic::QuicIo;
+        use iroh::Endpoint;
+        use iroh::endpoint::presets;
+
+        // 1. Device endpoint — simulates the runtime side.
+        let device_ep = Endpoint::builder(presets::N0)
+            .alpns(vec![IROH_ALPN.to_vec()])
+            .bind()
+            .await
+            .expect("device endpoint should bind");
+
+        let device_addr = device_ep.addr();
+
+        // 2. CLI endpoint — simulates the dialling side.
+        let cli_ep = create_cli_iroh_endpoint()
+            .await
+            .expect("cli endpoint should bind");
+
+        // 3. Device accept loop: accept one connection, one bi-stream.
+        //    Echos whatever bytes it receives back to the sender.
+        let device_task = tokio::spawn(async move {
+            let incoming =
+                tokio::time::timeout(std::time::Duration::from_secs(20), device_ep.accept())
+                    .await
+                    .expect("accept did not complete within timeout")
+                    .expect("endpoint closed before accept");
+
+            let conn = incoming.await.expect("iroh handshake failed");
+
+            let (mut send, mut recv) = conn.accept_bi().await.expect("accept_bi failed");
+
+            // Echo 5 bytes back.
+            let mut buf = [0u8; 5];
+            recv.read_exact(&mut buf)
+                .await
+                .expect("device: read failed");
+            send.write_all(&buf).await.expect("device: write failed");
+            send.finish().expect("device: finish failed");
+
+            // Wait for the CLI to close the connection before tearing down the
+            // endpoint. Closing immediately after `finish()` races the echoed
+            // bytes on fast (localhost) paths — the CONNECTION_CLOSE can reach
+            // the peer before the stream data, making the CLI's read_exact fail.
+            conn.closed().await;
+            device_ep.close().await;
+        });
+
+        // 4. CLI connects and wraps the stream in QuicIo::from_iroh.
+        let conn = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            try_iroh_connect(&cli_ep, device_addr),
+        )
+        .await
+        .expect("connect timed out")
+        .expect("iroh connect failed");
+
+        let (send, recv) = conn.open_bi().await.expect("cli: open_bi failed");
+        let mut io = QuicIo::from_iroh(recv, send);
+
+        // Write 5 bytes through QuicIo::from_iroh and read the echo back.
+        io.write_all(b"iroh!").await.expect("cli: write failed");
+        io.flush().await.expect("cli: flush failed");
+
+        let mut reply = [0u8; 5];
+        io.read_exact(&mut reply)
+            .await
+            .expect("cli: read_exact failed");
+
+        assert_eq!(&reply, b"iroh!", "echoed data must match what was sent");
+
+        cli_ep.close().await;
+        device_task.await.expect("device task panicked");
+    }
+
+    // ── full stream-type framing over iroh ────────────────────────────
+
+    /// Verify that open_iroh_stream() sends the StreamType framing header and
+    /// that from_incoming_stream() on the device side can parse it back.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_open_iroh_stream_framing() {
+        use crate::streams::stream_type::StreamType;
+        use iroh::Endpoint;
+        use iroh::endpoint::presets;
+
+        let device_ep = Endpoint::builder(presets::N0)
+            .alpns(vec![IROH_ALPN.to_vec()])
+            .bind()
+            .await
+            .expect("device ep");
+        let device_addr = device_ep.addr();
+
+        let cli_ep = create_cli_iroh_endpoint().await.expect("cli ep");
+
+        // The StreamType that the CLI will send.
+        let expected_stream_type = StreamType::Metrics {
+            token: "tok".into(),
+        };
+        let expected_clone = serde_json::to_string(&expected_stream_type).unwrap();
+
+        let device_task = tokio::spawn(async move {
+            let incoming =
+                tokio::time::timeout(std::time::Duration::from_secs(20), device_ep.accept())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            let conn = incoming.await.unwrap();
+            let (_send, mut recv) = conn.accept_bi().await.unwrap();
+
+            // Parse the StreamType header exactly as the router does.
+            let parsed = StreamType::from_incoming_stream(&mut recv)
+                .await
+                .expect("from_incoming_stream failed");
+
+            let parsed_json = serde_json::to_string(&parsed).unwrap();
+            assert_eq!(
+                parsed_json, expected_clone,
+                "parsed StreamType must match what the CLI sent"
+            );
+
+            device_ep.close().await;
+        });
+
+        let conn = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            try_iroh_connect(&cli_ep, device_addr),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let _io = open_iroh_stream(&conn, expected_stream_type)
+            .await
+            .expect("open_iroh_stream failed");
+
+        // Wait for the device to finish parsing before closing the endpoint.
+        // Closing the endpoint first would terminate the connection and cause
+        // accept_bi() on the device side to fail with ApplicationClosed.
+        device_task.await.expect("device task panicked");
+        cli_ep.close().await;
+    }
+}

--- a/m87-client/src/streams/iroh_p2p.rs
+++ b/m87-client/src/streams/iroh_p2p.rs
@@ -8,6 +8,7 @@
 use anyhow::{Context, Result};
 use iroh::endpoint::Connection as IrohConnection;
 use iroh::{Endpoint as IrohEndpoint, EndpointAddr};
+use m87_shared::iroh_ticket::SignedIrohTicket;
 use serde::Deserialize;
 use std::time::Duration;
 use tracing::{debug, warn};
@@ -18,31 +19,53 @@ use crate::streams::stream_type::StreamType;
 /// ALPN used for direct iroh P2P connections between CLI and device.
 pub const IROH_ALPN: &[u8] = b"m87-iroh-p2p/1";
 
-/// Timeout when attempting an iroh P2P connection.
-const IROH_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+/// How long to wait for a direct iroh connection before falling back to the
+/// server relay.
+///
+/// This only bites when iroh *cannot* connect (no direct path AND the iroh
+/// relay is unreachable) — a working connection, even over a slow/high-latency
+/// IoT uplink, establishes in a few seconds and never hits this. So the value
+/// is a trade-off: low enough that a genuinely unreachable peer falls back to
+/// the relay quickly, high enough that a slow-but-viable link (lossy cellular,
+/// satellite RTTs) still completes the QUIC + holepunch handshake rather than
+/// being cut off and losing the direct path for the whole session. 10s keeps
+/// the fallback snappy while leaving comfortable headroom for slow IoT links.
+const IROH_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Response body from `GET /device/{id}/iroh-addr`.
 #[derive(Deserialize)]
 struct IrohAddrResponse {
     iroh_node_addr: String,
+    ticket: SignedIrohTicket,
 }
 
-/// Fetch the iroh [`EndpointAddr`] for a device from the m87 server.
+/// Fetch the iroh [`EndpointAddr`] and a server-signed connection ticket for a
+/// device.
 ///
 /// `server_url` is the HTTPS base URL, `token` is the user bearer token,
-/// `device_id` is the MongoDB ObjectId string of the device.
+/// `device_id` is the MongoDB ObjectId string of the device. The ticket is
+/// presented to the device to authorize the direct connection.
 pub async fn fetch_device_iroh_addr(
     server_url: &str,
     token: &str,
     device_id: &str,
-) -> Result<EndpointAddr> {
+    trust_invalid_server_cert: bool,
+) -> Result<(EndpointAddr, SignedIrohTicket)> {
     let url = format!(
         "{}/device/{}/iroh-addr",
         server_url.trim_end_matches('/'),
         device_id
     );
 
-    let resp = reqwest::Client::new()
+    // Honour the same cert-trust setting the rest of the CLI uses; otherwise
+    // self-signed / staging servers reject this call and iroh silently never
+    // engages (every connection falls back to the relay).
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(trust_invalid_server_cert)
+        .build()
+        .context("building iroh-addr http client")?;
+
+    let resp = client
         .get(&url)
         .bearer_auth(token)
         .timeout(Duration::from_secs(5))
@@ -59,7 +82,7 @@ pub async fn fetch_device_iroh_addr(
     let addr: EndpointAddr =
         serde_json::from_str(&body.iroh_node_addr).context("deserializing iroh EndpointAddr")?;
 
-    Ok(addr)
+    Ok((addr, body.ticket))
 }
 
 /// Create an ephemeral iroh endpoint for the CLI (no ALPNs needed — we are
@@ -106,45 +129,90 @@ pub async fn open_iroh_stream(conn: &IrohConnection, stream_type: StreamType) ->
     Ok(QuicIo::from_iroh(recv, send))
 }
 
-/// High-level helper: fetch iroh addr from server, try direct connection,
-/// open stream. Returns `None` if anything fails (caller falls back to relay).
-pub async fn try_open_iroh_stream(
+/// Environment variable that disables the iroh direct-connection layer,
+/// forcing all CLI traffic over the server relay. Doubles as an operational
+/// kill switch and as the lever the e2e tests use to exercise relay fallback.
+pub const DISABLE_IROH_ENV: &str = "M87_DISABLE_IROH";
+
+/// Whether the iroh direct-connection layer has been disabled via
+/// [`DISABLE_IROH_ENV`] (`1` / `true` / `yes`, case-insensitive).
+pub fn iroh_disabled() -> bool {
+    std::env::var(DISABLE_IROH_ENV)
+        .map(|v| {
+            let v = v.trim();
+            v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("yes")
+        })
+        .unwrap_or(false)
+}
+
+/// High-level helper: fetch the device's iroh addr from the server and try to
+/// establish a direct connection.
+///
+/// Returns the endpoint **and** the connection on success — the endpoint owns
+/// the local socket and its driver, so it MUST be kept alive for the whole
+/// lifetime of the connection (dropping it tears the connection down). Returns
+/// `None` — so the caller transparently falls back to the server relay — when
+/// iroh is disabled or any step (addr lookup, bind, connect) fails.
+pub async fn try_iroh_connection(
     server_url: &str,
     token: &str,
     device_id: &str,
-    stream_type: StreamType,
-) -> Option<(IrohConnection, QuicIo)> {
-    let addr = match fetch_device_iroh_addr(server_url, token, device_id).await {
-        Ok(a) => a,
-        Err(e) => {
-            debug!("iroh: could not get device addr: {e}");
-            return None;
-        }
-    };
+    trust_invalid_server_cert: bool,
+) -> Option<(IrohEndpoint, IrohConnection)> {
+    if iroh_disabled() {
+        debug!("iroh: disabled via {DISABLE_IROH_ENV}, using server relay");
+        return None;
+    }
+
+    let (addr, ticket) =
+        match fetch_device_iroh_addr(server_url, token, device_id, trust_invalid_server_cert).await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("iroh: could not get device addr (will use relay): {e}");
+                return None;
+            }
+        };
 
     let ep = match create_cli_iroh_endpoint().await {
         Ok(e) => e,
         Err(e) => {
-            warn!("iroh: could not create endpoint: {e}");
+            warn!("iroh: could not create endpoint (will use relay): {e}");
             return None;
         }
     };
 
     let conn = match try_iroh_connect(&ep, addr).await {
-        Ok(c) => c,
+        Ok(conn) => conn,
         Err(e) => {
             debug!("iroh: direct connect failed (will use relay): {e}");
             return None;
         }
     };
 
-    match open_iroh_stream(&conn, stream_type).await {
-        Ok(io) => Some((conn, io)),
-        Err(e) => {
-            warn!("iroh: stream open failed: {e}");
-            None
-        }
+    // Authorize the connection: the device's accept loop reads this ticket from
+    // a uni-stream before it will serve any data streams.
+    if let Err(e) = send_iroh_ticket(&conn, &ticket).await {
+        debug!("iroh: failed to send ticket (will use relay): {e}");
+        return None;
     }
+
+    Some((ep, conn))
+}
+
+/// Send the server-signed ticket over a uni-stream, matching the framing the
+/// device's accept loop expects (`u16` big-endian length + JSON body).
+async fn send_iroh_ticket(conn: &IrohConnection, ticket: &SignedIrohTicket) -> Result<()> {
+    let json = serde_json::to_vec(ticket).context("serializing iroh ticket")?;
+    if json.len() > u16::MAX as usize {
+        anyhow::bail!("iroh ticket too large ({} bytes)", json.len());
+    }
+
+    let mut send = conn.open_uni().await.context("opening iroh ticket stream")?;
+    send.write_all(&(json.len() as u16).to_be_bytes()).await?;
+    send.write_all(&json).await?;
+    send.finish().context("finishing iroh ticket stream")?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -308,6 +376,62 @@ mod tests {
         // Wait for the device to finish parsing before closing the endpoint.
         // Closing the endpoint first would terminate the connection and cause
         // accept_bi() on the device side to fail with ApplicationClosed.
+        device_task.await.expect("device task panicked");
+        cli_ep.close().await;
+    }
+
+    // ── datagram transport (used by UDP forwarding) ────────────────────
+
+    /// Verify iroh negotiates datagram support and a datagram round-trips
+    /// between two endpoints — the transport UDP forwarding relies on.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_iroh_datagram_roundtrip() {
+        use iroh::Endpoint;
+        use iroh::endpoint::presets;
+
+        let device_ep = Endpoint::builder(presets::N0)
+            .alpns(vec![IROH_ALPN.to_vec()])
+            .bind()
+            .await
+            .expect("device ep");
+        let device_addr = device_ep.addr();
+        let cli_ep = create_cli_iroh_endpoint().await.expect("cli ep");
+
+        let device_task = tokio::spawn(async move {
+            let incoming =
+                tokio::time::timeout(std::time::Duration::from_secs(20), device_ep.accept())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            let conn = incoming.await.unwrap();
+            // Datagrams are unreliable; the sender retries, we read the first.
+            let d = tokio::time::timeout(std::time::Duration::from_secs(10), conn.read_datagram())
+                .await
+                .expect("datagram did not arrive")
+                .expect("read_datagram failed");
+            assert_eq!(&d[..], b"ping", "datagram payload must match");
+            device_ep.close().await;
+        });
+
+        let conn = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            try_iroh_connect(&cli_ep, device_addr),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            conn.max_datagram_size().is_some(),
+            "iroh must negotiate datagram support for UDP forwarding"
+        );
+
+        // Unreliable transport: send a few times until the device reads one.
+        for _ in 0..20 {
+            let _ = conn.send_datagram(bytes::Bytes::from_static(b"ping"));
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
         device_task.await.expect("device task panicked");
         cli_ep.close().await;
     }

--- a/m87-client/src/streams/mod.rs
+++ b/m87-client/src/streams/mod.rs
@@ -1,6 +1,11 @@
 // Shared modules (used by both m87 runtime and m87 command line)
+pub mod iroh_p2p;
 pub mod quic;
 pub mod stream_type;
+
+// auth uses jsonwebtoken — only needed for runtime token validation
+#[cfg(feature = "runtime")]
+pub mod auth;
 
 // Runtime-specific: These modules handle incoming streams on the device side
 // Only compiled when runtime feature is enabled
@@ -8,6 +13,8 @@ pub mod stream_type;
 mod docker;
 #[cfg(feature = "runtime")]
 mod exec;
+#[cfg(feature = "runtime")]
+mod forward;
 #[cfg(feature = "runtime")]
 mod logs;
 #[cfg(feature = "runtime")]
@@ -22,7 +29,5 @@ mod shared;
 mod ssh;
 #[cfg(feature = "runtime")]
 mod terminal;
-#[cfg(feature = "runtime")]
-mod forward;
 #[cfg(feature = "runtime")]
 pub mod udp_manager;

--- a/m87-client/src/streams/quic.rs
+++ b/m87-client/src/streams/quic.rs
@@ -297,3 +297,158 @@ pub async fn open_quic_stream(conn: &quinn::Connection, stream_type: StreamType)
 
     Ok(QuicIo::from_quinn(recv, send))
 }
+
+// ── Transport-agnostic device connection (iroh-preferred, relay fallback) ─────
+
+/// A live connection to a device — either a direct iroh P2P connection or the
+/// quinn server-relay connection. Streams are opened the same way on both; the
+/// device routes iroh and relay streams through the same handler.
+///
+/// The owning value MUST be kept alive for as long as any stream opened from it
+/// is in use: each variant holds its `Endpoint`, whose driver task backs every
+/// stream. Dropping the connection tears those streams down.
+pub enum DeviceConnection {
+    /// Server-relay (quinn) connection.
+    Relay {
+        _endpoint: Endpoint,
+        conn: quinn::Connection,
+    },
+    /// Direct iroh P2P connection.
+    Iroh {
+        _endpoint: iroh::Endpoint,
+        conn: iroh::endpoint::Connection,
+    },
+}
+
+impl DeviceConnection {
+    /// Whether this is a direct iroh P2P connection (vs. the server relay).
+    pub fn is_iroh(&self) -> bool {
+        matches!(self, DeviceConnection::Iroh { .. })
+    }
+
+    /// Short transport label for logging / diagnostics.
+    pub fn transport(&self) -> &'static str {
+        match self {
+            DeviceConnection::Relay { .. } => "relay",
+            DeviceConnection::Iroh { .. } => "iroh",
+        }
+    }
+
+    /// Open a new bi-directional stream and send the stream-type header.
+    pub async fn open_stream(&self, stream_type: StreamType) -> Result<QuicIo> {
+        match self {
+            DeviceConnection::Relay { conn, .. } => open_quic_stream(conn, stream_type).await,
+            DeviceConnection::Iroh { conn, .. } => {
+                crate::streams::iroh_p2p::open_iroh_stream(conn, stream_type).await
+            }
+        }
+    }
+
+    /// Resolve when the connection closes, returning a human-readable reason.
+    /// Used by accept loops (e.g. port forwarding) to detect teardown.
+    pub async fn closed(&self) -> String {
+        match self {
+            DeviceConnection::Relay { conn, .. } => format!("{:?}", conn.closed().await),
+            DeviceConnection::Iroh { conn, .. } => format!("{:?}", conn.closed().await),
+        }
+    }
+
+    /// Send an unreliable datagram (used by UDP forwarding).
+    pub fn send_datagram(&self, data: bytes::Bytes) -> Result<()> {
+        match self {
+            DeviceConnection::Relay { conn, .. } => conn
+                .send_datagram(data)
+                .map_err(|e| anyhow::anyhow!("relay send_datagram: {e}")),
+            DeviceConnection::Iroh { conn, .. } => conn
+                .send_datagram(data)
+                .map_err(|e| anyhow::anyhow!("iroh send_datagram: {e}")),
+        }
+    }
+
+    /// Receive the next unreliable datagram.
+    pub async fn read_datagram(&self) -> Result<bytes::Bytes> {
+        match self {
+            DeviceConnection::Relay { conn, .. } => conn
+                .read_datagram()
+                .await
+                .map_err(|e| anyhow::anyhow!("relay read_datagram: {e}")),
+            DeviceConnection::Iroh { conn, .. } => conn
+                .read_datagram()
+                .await
+                .map_err(|e| anyhow::anyhow!("iroh read_datagram: {e}")),
+        }
+    }
+
+    /// Close the connection with an application reason.
+    pub fn close(&self, reason: &[u8]) {
+        match self {
+            DeviceConnection::Relay { conn, .. } => conn.close(0u32.into(), reason),
+            DeviceConnection::Iroh { conn, .. } => conn.close(0u32.into(), reason),
+        }
+    }
+}
+
+/// Establish a connection to a device, preferring a direct iroh P2P connection
+/// and transparently falling back to the server relay.
+///
+/// `server_url` is the device's manager-server base URL and `device_object_id`
+/// its MongoDB id — both needed to look up the device's advertised iroh addr.
+/// Any iroh failure (disabled, no advertised addr, unreachable) falls back to
+/// the relay, which is always available.
+pub async fn connect_device(
+    host: &str,
+    server_url: &str,
+    device_short_id: &str,
+    device_object_id: &str,
+    token: &str,
+    trust_invalid: bool,
+) -> Result<DeviceConnection> {
+    if let Some((endpoint, conn)) = crate::streams::iroh_p2p::try_iroh_connection(
+        server_url,
+        token,
+        device_object_id,
+        trust_invalid,
+    )
+    .await
+    {
+        debug!("connected to {device_short_id} via iroh (direct P2P)");
+        return Ok(DeviceConnection::Iroh {
+            _endpoint: endpoint,
+            conn,
+        });
+    }
+
+    let (endpoint, conn) = connect_quic_only(host, token, device_short_id, trust_invalid).await?;
+    debug!("connected to {device_short_id} via server relay");
+    Ok(DeviceConnection::Relay {
+        _endpoint: endpoint,
+        conn,
+    })
+}
+
+/// Open a single stream to a device over an iroh-preferred, relay-fallback
+/// connection. Mirrors [`open_quic_io`] but is transport-agnostic.
+///
+/// Returns the connection alongside the stream — keep the connection alive for
+/// the lifetime of the returned [`QuicIo`].
+pub async fn open_device_io(
+    host: &str,
+    server_url: &str,
+    token: &str,
+    device_short_id: &str,
+    device_object_id: &str,
+    stream_type: StreamType,
+    trust_invalid: bool,
+) -> Result<(DeviceConnection, QuicIo)> {
+    let conn = connect_device(
+        host,
+        server_url,
+        device_short_id,
+        device_object_id,
+        token,
+        trust_invalid,
+    )
+    .await?;
+    let io = conn.open_stream(stream_type).await?;
+    Ok((conn, io))
+}

--- a/m87-client/src/streams/quic.rs
+++ b/m87-client/src/streams/quic.rs
@@ -386,6 +386,24 @@ impl DeviceConnection {
             DeviceConnection::Iroh { conn, .. } => conn.close(0u32.into(), reason),
         }
     }
+
+    /// Gracefully close the connection and, for iroh, its endpoint too.
+    ///
+    /// Without the explicit `endpoint.close().await`, dropping an iroh
+    /// connection makes iroh log `Endpoint dropped without calling
+    /// Endpoint::close. Aborting ungracefully` and emit a spurious
+    /// connection-closed error on teardown — noisy for users, and it can leak
+    /// into captured command output. Call this when a command is done with the
+    /// connection (streams already finished).
+    pub async fn close_gracefully(self, reason: &[u8]) {
+        match self {
+            DeviceConnection::Relay { conn, .. } => conn.close(0u32.into(), reason),
+            DeviceConnection::Iroh { conn, _endpoint } => {
+                conn.close(0u32.into(), reason);
+                _endpoint.close().await;
+            }
+        }
+    }
 }
 
 /// Establish a connection to a device, preferring a direct iroh P2P connection

--- a/m87-client/src/streams/quic.rs
+++ b/m87-client/src/streams/quic.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
+use iroh::endpoint::{RecvStream as IrohRecvStream, SendStream as IrohSendStream};
 use quinn::{ClientConfig, Endpoint, IdleTimeout};
 use quinn_proto::crypto::rustls::QuicClientConfig;
 use rustls::{ClientConfig as RustlsClientConfig, RootCertStore};
+use std::io;
 use std::time::Duration;
 use std::{net::SocketAddr, sync::Arc};
 use std::{pin::Pin, task::Poll};
@@ -9,7 +11,144 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tracing::{debug, error, warn};
 
 use crate::streams::stream_type::StreamType;
-use crate::util::tls::NoVerify; // reuse the same NoVerify struct
+use crate::util::tls::NoVerify;
+
+// ── Transport-agnostic stream wrappers ──────────────────────────────────────
+
+/// Either a quinn or an iroh receive stream.
+pub enum QuicRecvStream {
+    Quinn(quinn::RecvStream),
+    Iroh(IrohRecvStream),
+}
+
+/// Either a quinn or an iroh send stream.
+pub enum QuicSendStream {
+    Quinn(quinn::SendStream),
+    Iroh(IrohSendStream),
+}
+
+impl QuicSendStream {
+    /// Signal end of stream (QUIC FIN). Works for both transports.
+    pub fn finish(&mut self) -> io::Result<()> {
+        match self {
+            QuicSendStream::Quinn(s) => s
+                .finish()
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e)),
+            QuicSendStream::Iroh(s) => s
+                .finish()
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e)),
+        }
+    }
+}
+
+impl AsyncRead for QuicRecvStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match &mut *self {
+            QuicRecvStream::Quinn(s) => Pin::new(s).poll_read(cx, buf),
+            QuicRecvStream::Iroh(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for QuicSendStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        data: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            QuicSendStream::Quinn(s) => Pin::new(s)
+                .poll_write(cx, data)
+                .map(|r| r.map_err(|e| io::Error::new(io::ErrorKind::Other, e))),
+            QuicSendStream::Iroh(s) => Pin::new(s)
+                .poll_write(cx, data)
+                .map(|r| r.map_err(|e| io::Error::new(io::ErrorKind::Other, e))),
+        }
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        match &mut *self {
+            QuicSendStream::Quinn(s) => Pin::new(s).poll_flush(cx),
+            QuicSendStream::Iroh(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        match &mut *self {
+            QuicSendStream::Quinn(s) => Pin::new(s).poll_shutdown(cx),
+            QuicSendStream::Iroh(s) => Pin::new(s).poll_shutdown(cx),
+        }
+    }
+}
+
+// ── QuicIo: combined read+write stream pair ──────────────────────────────────
+
+pub struct QuicIo {
+    pub recv: QuicRecvStream,
+    pub send: QuicSendStream,
+}
+
+impl QuicIo {
+    pub fn from_quinn(recv: quinn::RecvStream, send: quinn::SendStream) -> Self {
+        QuicIo {
+            recv: QuicRecvStream::Quinn(recv),
+            send: QuicSendStream::Quinn(send),
+        }
+    }
+
+    pub fn from_iroh(recv: IrohRecvStream, send: IrohSendStream) -> Self {
+        QuicIo {
+            recv: QuicRecvStream::Iroh(recv),
+            send: QuicSendStream::Iroh(send),
+        }
+    }
+}
+
+impl AsyncRead for QuicIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.recv).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for QuicIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        data: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.send).poll_write(cx, data)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.send).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.send).poll_shutdown(cx)
+    }
+}
+
+// ── DNS + TLS helpers ─────────────────────────────────────────────────────────
 
 async fn resolve_host(host: &str, port: u16) -> Result<SocketAddr> {
     for i in 0..10 {
@@ -21,22 +160,21 @@ async fn resolve_host(host: &str, port: u16) -> Result<SocketAddr> {
                     }
                 }
             }
-            Err(_) => { /* ignore and retry */ }
+            Err(_) => {}
         }
-
         let backoff_ms = 200 + i * 150;
         tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
     }
-
     Err(anyhow::anyhow!("DNS resolution failed after retries"))
 }
+
+// ── Quinn / server-relay connection ──────────────────────────────────────────
 
 pub async fn get_quic_connection(
     host_name: &str,
     token: &str,
     trust_invalid_server_cert: bool,
 ) -> Result<(Endpoint, quinn::Connection)> {
-    // if hostname ends with :port extract port otherwise use 443
     let port = if let Some(Ok(port)) = host_name
         .rsplit_once(':')
         .map(|(_, port)| port.parse::<u16>())
@@ -50,13 +188,11 @@ pub async fn get_quic_connection(
         .unwrap_or(host_name);
     let server_addr = resolve_host(port_free_host_name, port).await?;
 
-    // 2. Root store (system roots)
     let mut root_store = RootCertStore::empty();
     root_store
         .roots
         .extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
-    // 3. Build rustls QUIC client config
     debug!(
         "Creating QUIC client config with trust_invalid_server_cert={}",
         trust_invalid_server_cert
@@ -74,17 +210,14 @@ pub async fn get_quic_connection(
             .with_no_client_auth()
     };
 
-    // 4. QUIC requires ALPN
     tls.alpn_protocols = vec![b"m87-quic".to_vec()];
 
-    // 5. Convert rustls → QUIC crypto config
     let crypto =
         Arc::new(QuicClientConfig::try_from(tls).context("failed converting rustls→quic config")?);
 
     let mut client_cfg = ClientConfig::new(crypto);
     let mut transport = quinn::TransportConfig::default();
     transport.keep_alive_interval(Some(Duration::from_secs(5)));
-    //make sure we dont black hole packets
     transport
         .initial_mtu(1200)
         .min_mtu(1200)
@@ -95,7 +228,6 @@ pub async fn get_quic_connection(
     ));
     client_cfg.transport_config(Arc::new(transport));
 
-    // 6. Create QUIC client endpoint (local ephemeral port)
     let mut endpoint =
         Endpoint::client("[::]:0".parse().unwrap()).context("failed creating QUIC endpoint")?;
     endpoint.set_default_client_config(client_cfg);
@@ -126,47 +258,6 @@ pub async fn get_quic_connection(
     send.finish()?;
 
     Ok((endpoint, conn))
-}
-
-pub struct QuicIo {
-    pub recv: quinn::RecvStream,
-    pub send: quinn::SendStream,
-}
-
-impl AsyncRead for QuicIo {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.recv).poll_read(cx, buf)
-    }
-}
-
-impl AsyncWrite for QuicIo {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        data: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.send)
-            .poll_write(cx, data)
-            .map_err(|e| std::io::Error::from(e))
-    }
-
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.send).poll_flush(cx)
-    }
-
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.send).poll_shutdown(cx)
-    }
 }
 
 pub async fn open_quic_io(
@@ -204,5 +295,5 @@ pub async fn open_quic_stream(conn: &quinn::Connection, stream_type: StreamType)
 
     debug!("Stream opened");
 
-    Ok(QuicIo { recv, send })
+    Ok(QuicIo::from_quinn(recv, send))
 }

--- a/m87-client/src/streams/stream_type.rs
+++ b/m87-client/src/streams/stream_type.rs
@@ -339,7 +339,10 @@ impl StreamType {
         }
     }
 
-    pub async fn from_incoming_stream(recv: &mut quinn::RecvStream) -> anyhow::Result<StreamType> {
+    pub async fn from_incoming_stream(
+        recv: &mut (impl tokio::io::AsyncRead + Unpin),
+    ) -> anyhow::Result<StreamType> {
+        use tokio::io::AsyncReadExt;
         // length header
         let mut len_buf = [0u8; 4];
         recv.read_exact(&mut len_buf).await?;
@@ -505,8 +508,7 @@ mod tests {
     #[test]
     fn test_existing_single_port_with_host() {
         // Ensure existing functionality still works
-        let targets =
-            ForwardTarget::from_list(vec!["8080:192.168.1.50:9090".to_string()]).unwrap();
+        let targets = ForwardTarget::from_list(vec!["8080:192.168.1.50:9090".to_string()]).unwrap();
         assert_eq!(targets.len(), 1);
         match &targets[0] {
             ForwardTarget::Tcp(t) => {

--- a/m87-client/src/tui/exec.rs
+++ b/m87-client/src/tui/exec.rs
@@ -1,4 +1,4 @@
-use crate::streams::quic::open_quic_io;
+use crate::streams::quic::open_device_io;
 use crate::streams::stream_type::StreamType;
 use crate::{auth::AuthManager, config::Config, devices, util::shutdown::SHUTDOWN};
 use anyhow::{Context, Result};
@@ -44,10 +44,12 @@ pub async fn run_exec_capture(
     let stream_type = StreamType::Exec {
         token: token.to_string(),
     };
-    let (_, io) = open_quic_io(
+    let (_conn, io) = open_device_io(
         &resolved.host,
+        &resolved.url,
         &token,
         &resolved.short_id,
+        &resolved.id,
         stream_type,
         config.trust_invalid_server_cert,
     )
@@ -76,10 +78,12 @@ pub async fn run_exec(device: &str, command: Vec<String>, stdin: bool, tty: bool
     let stream_type = StreamType::Exec {
         token: token.to_string(),
     };
-    let (_, io) = open_quic_io(
+    let (_conn, io) = open_device_io(
         &resolved.host,
+        &resolved.url,
         &token,
         &resolved.short_id,
+        &resolved.id,
         stream_type,
         config.trust_invalid_server_cert,
     )

--- a/m87-client/src/tui/log.rs
+++ b/m87-client/src/tui/log.rs
@@ -1,4 +1,4 @@
-use crate::streams::quic::open_quic_io;
+use crate::streams::quic::open_device_io;
 use crate::streams::stream_type::StreamType;
 use crate::{auth::AuthManager, config::Config, devices, util::shutdown::SHUTDOWN};
 use anyhow::{Context, Result};
@@ -18,10 +18,12 @@ pub async fn run_logs(device: &str) -> Result<()> {
     let stream_type = StreamType::Logs {
         token: token.to_string(),
     };
-    let (_, mut io) = open_quic_io(
+    let (_conn, mut io) = open_device_io(
         &resolved.host,
+        &resolved.url,
         &token,
         &resolved.short_id,
+        &resolved.id,
         stream_type,
         config.trust_invalid_server_cert,
     )

--- a/m87-client/src/tui/log.rs
+++ b/m87-client/src/tui/log.rs
@@ -18,7 +18,7 @@ pub async fn run_logs(device: &str) -> Result<()> {
     let stream_type = StreamType::Logs {
         token: token.to_string(),
     };
-    let (_conn, mut io) = open_device_io(
+    let (conn, mut io) = open_device_io(
         &resolved.host,
         &resolved.url,
         &token,
@@ -77,6 +77,11 @@ pub async fn run_logs(device: &str) -> Result<()> {
         _ = stdin_rx.recv() => {},
         _ = SHUTDOWN.cancelled() => {},
     }
+
+    // Stop reading, then tear the connection down gracefully so iroh doesn't log
+    // an "Aborting ungracefully" endpoint-drop error on exit.
+    read_task.abort();
+    conn.close_gracefully(b"logs closed").await;
 
     println!("\nLogs stream closed.");
     Ok(())

--- a/m87-client/src/tui/metric.rs
+++ b/m87-client/src/tui/metric.rs
@@ -2,7 +2,7 @@ use crate::{
     auth::AuthManager,
     config::Config,
     devices,
-    streams::{quic::open_quic_io, stream_type::StreamType},
+    streams::{quic::open_device_io, stream_type::StreamType},
 };
 use anyhow::{Result, anyhow};
 use m87_shared::metrics::SystemMetrics;
@@ -33,10 +33,12 @@ async fn run_metrics_inner(device: &str) -> Result<()> {
         token: token.clone(),
     };
 
-    let (conn, io) = open_quic_io(
+    let (conn, io) = open_device_io(
         &resolved.host,
+        &resolved.url,
         &token,
         &resolved.short_id,
+        &resolved.id,
         stream_type,
         config.trust_invalid_server_cert,
     )

--- a/m87-client/src/tui/shell.rs
+++ b/m87-client/src/tui/shell.rs
@@ -1,4 +1,4 @@
-use crate::streams::quic::open_quic_io;
+use crate::streams::quic::open_device_io;
 use crate::streams::stream_type::StreamType;
 use crate::util::shutdown::SHUTDOWN;
 use crate::{auth::AuthManager, config::Config, devices};
@@ -22,10 +22,12 @@ pub async fn run_shell(device: &str) -> Result<()> {
         term,
     };
     tracing::info!("Connecting to device.");
-    let (_, io) = open_quic_io(
+    let (_conn, io) = open_device_io(
         &resolved.host,
+        &resolved.url,
         &token,
         &resolved.short_id,
+        &resolved.id,
         stream_type,
         config.trust_invalid_server_cert,
     )

--- a/m87-client/src/tui/shell.rs
+++ b/m87-client/src/tui/shell.rs
@@ -4,6 +4,7 @@ use crate::util::shutdown::SHUTDOWN;
 use crate::{auth::AuthManager, config::Config, devices};
 use anyhow::Result;
 use termion::{raw::IntoRawMode, terminal_size};
+use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::mpsc;
@@ -124,10 +125,7 @@ pub async fn run_shell(device: &str) -> Result<()> {
         let mut buf = [0u8; 8192];
 
         loop {
-            let n = match reader.read(&mut buf).await? {
-                Some(n) => n,
-                None => break,
-            };
+            let n = reader.read(&mut buf).await?;
             if n == 0 {
                 break;
             }

--- a/m87-server/Dockerfile.e2e
+++ b/m87-server/Dockerfile.e2e
@@ -1,0 +1,21 @@
+# E2E-only image. Copies a host-built (native glibc) m87-server binary into a
+# glibc-matched base — NO cargo build happens here. The binary is compiled once
+# on the host (reusing the cargo `target/` cache) and staged into this build
+# context by tests/src/e2e_containers/setup.rs, so this image builds in seconds.
+#
+# NOT used for production releases — see m87-server/Dockerfile for the portable
+# manylinux2014 -> distroless build. ubuntu:24.04 is chosen so its glibc matches
+# the GitHub `ubuntu-24.04` runner that compiles the binary (glibc is backward-
+# but not forward-compatible, so the runtime base must be >= the build host).
+FROM ubuntu:24.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Binary is staged next to this Dockerfile by setup.rs (build context = temp dir).
+COPY m87-server /app/m87-server
+
+ENTRYPOINT ["/app/m87-server"]

--- a/m87-server/src/api/device.rs
+++ b/m87-server/src/api/device.rs
@@ -37,7 +37,38 @@ pub fn create_route() -> Router<AppState> {
             "/{id}/access/{email_or_org_id}",
             delete(remove_device_access),
         )
+        .route("/{id}/iroh-addr", get(get_device_iroh_addr))
         .merge(deploy_spec_route())
+}
+
+#[derive(serde::Serialize)]
+struct IrohAddrResponse {
+    iroh_node_addr: String,
+}
+
+async fn get_device_iroh_addr(
+    claims: Claims,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> ServerAppResult<IrohAddrResponse> {
+    let device_id =
+        ObjectId::parse_str(&id).map_err(|_| ServerError::bad_request("Invalid ObjectId"))?;
+
+    let device_opt = claims
+        .find_one_with_scope_and_role(&state.db.devices(), doc! { "_id": device_id }, Role::Viewer)
+        .await?;
+    let device = device_opt.ok_or_else(|| ServerError::not_found("Device not found"))?;
+
+    let iroh_addr = state.relay.get_iroh_addr(&device.short_id).await;
+    match iroh_addr {
+        Some(addr) => Ok(ServerResponse::builder()
+            .body(IrohAddrResponse {
+                iroh_node_addr: addr,
+            })
+            .status_code(axum::http::StatusCode::OK)
+            .build()),
+        None => Err(ServerError::not_found("iroh not available")),
+    }
 }
 
 async fn get_devices(

--- a/m87-server/src/api/device.rs
+++ b/m87-server/src/api/device.rs
@@ -3,6 +3,7 @@ use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use m87_shared::deploy_spec::{FailureAggQuery, FailureAggResponse};
 use m87_shared::device::{AddDeviceAccessBody, AuditLog, DeviceStatus};
+use m87_shared::iroh_ticket::{IrohTicket, SignedIrohTicket};
 use m87_shared::roles::Role;
 use m87_shared::users::User;
 use mongodb::bson::doc;
@@ -44,7 +45,14 @@ pub fn create_route() -> Router<AppState> {
 #[derive(serde::Serialize)]
 struct IrohAddrResponse {
     iroh_node_addr: String,
+    /// Short-lived, server-signed ticket the CLI presents to the device to
+    /// authorize the direct connection.
+    ticket: SignedIrohTicket,
 }
+
+/// How long an issued iroh connection ticket is valid. Short: the CLI fetches
+/// a fresh one per connection attempt.
+const IROH_TICKET_TTL_MS: u64 = 60_000;
 
 async fn get_device_iroh_addr(
     claims: Claims,
@@ -54,21 +62,38 @@ async fn get_device_iroh_addr(
     let device_id =
         ObjectId::parse_str(&id).map_err(|_| ServerError::bad_request("Invalid ObjectId"))?;
 
+    // The role check here IS the authorization: a ticket is only minted for a
+    // caller the server has already verified can reach this device.
     let device_opt = claims
         .find_one_with_scope_and_role(&state.db.devices(), doc! { "_id": device_id }, Role::Viewer)
         .await?;
     let device = device_opt.ok_or_else(|| ServerError::not_found("Device not found"))?;
 
-    let iroh_addr = state.relay.get_iroh_addr(&device.short_id).await;
-    match iroh_addr {
-        Some(addr) => Ok(ServerResponse::builder()
-            .body(IrohAddrResponse {
-                iroh_node_addr: addr,
-            })
-            .status_code(axum::http::StatusCode::OK)
-            .build()),
-        None => Err(ServerError::not_found("iroh not available")),
-    }
+    let addr = state
+        .relay
+        .get_iroh_addr(&device.short_id)
+        .await
+        .ok_or_else(|| ServerError::not_found("iroh not available"))?;
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let ticket = IrohTicket {
+        device_short_id: device.short_id.clone(),
+        subject: claims.user_email.clone(),
+        issued_at_ms: now_ms,
+        expires_at_ms: now_ms + IROH_TICKET_TTL_MS,
+    };
+    let signed = state.iroh_ticket_signer.sign(&ticket);
+
+    Ok(ServerResponse::builder()
+        .body(IrohAddrResponse {
+            iroh_node_addr: addr,
+            ticket: signed,
+        })
+        .status_code(axum::http::StatusCode::OK)
+        .build())
 }
 
 async fn get_devices(

--- a/m87-server/src/api/quic.rs
+++ b/m87-server/src/api/quic.rs
@@ -356,6 +356,11 @@ async fn run_heartbeat_loop(
                     }
                 };
 
+                // Store iroh addr if device advertised one
+                if let Some(addr) = &req.iroh_node_addr {
+                    state.relay.set_iroh_addr(&device_id, addr.clone()).await;
+                }
+
                 let device_opt = state.db.devices().find_one(doc!{ "short_id": &device_id }).await?;
 
                 let Some(device) = device_opt else {

--- a/m87-server/src/api/quic.rs
+++ b/m87-server/src/api/quic.rs
@@ -368,7 +368,11 @@ async fn run_heartbeat_loop(
                     break;
                 };
 
-                let body = device.handle_heartbeat(claims.clone(), &state.db, req, &state.config).await?;
+                let mut body = device.handle_heartbeat(claims.clone(), &state.db, req, &state.config).await?;
+
+                // Advertise the iroh ticket-signing public key so the device can
+                // verify tickets CLIs present on direct connections.
+                body.iroh_ticket_pubkey = Some(state.iroh_ticket_signer.public_b64());
 
                 info!("sending heartbeat response");
                 match write_msg(&mut send, &body).await {

--- a/m87-server/src/api/serve.rs
+++ b/m87-server/src/api/serve.rs
@@ -49,10 +49,33 @@ pub async fn serve(
 
     let (reload_tx, reload_rx) = watch::channel(());
 
+    // Ed25519 signing key for direct-connection (iroh) authorization tickets.
+    // A stable fleet-wide key (M87_IROH_TICKET_KEY, base64 32-byte seed) lets
+    // any server instance sign tickets a device will trust; otherwise we mint
+    // an ephemeral key (fine for single-server dev / e2e).
+    let iroh_ticket_signer = Arc::new(
+        match std::env::var("M87_IROH_TICKET_KEY") {
+            Ok(seed) if !seed.trim().is_empty() => {
+                m87_shared::iroh_ticket::IrohTicketSigner::from_seed_b64(&seed)
+                    .expect("M87_IROH_TICKET_KEY must be a base64 32-byte ed25519 seed")
+            }
+            _ => {
+                let signer = m87_shared::iroh_ticket::IrohTicketSigner::generate();
+                tracing::warn!(
+                    "M87_IROH_TICKET_KEY not set — using an ephemeral iroh ticket key \
+                     (pubkey {}). Set a stable fleet-wide key in production.",
+                    signer.public_b64()
+                );
+                signer
+            }
+        },
+    );
+
     let state = AppState {
         db: db.clone(),
         config: cfg.clone(),
         relay: relay.clone(),
+        iroh_ticket_signer,
     };
 
     // CORS for REST

--- a/m87-server/src/models/device.rs
+++ b/m87-server/src/models/device.rs
@@ -353,6 +353,7 @@ impl DeviceDoc {
                 lifecycle_updates: pending_updates.clone(),
                 pending_job_runs: pending_job_runs.clone(),
                 iroh_supported: false,
+                iroh_ticket_pubkey: None,
             });
         }
 
@@ -393,6 +394,7 @@ impl DeviceDoc {
             lifecycle_updates: pending_updates,
             pending_job_runs,
             iroh_supported: false,
+            iroh_ticket_pubkey: None,
         };
         Ok(resp)
     }

--- a/m87-server/src/models/device.rs
+++ b/m87-server/src/models/device.rs
@@ -352,6 +352,7 @@ impl DeviceDoc {
                 received_report_hashes: ack_hash_list,
                 lifecycle_updates: pending_updates.clone(),
                 pending_job_runs: pending_job_runs.clone(),
+                iroh_supported: false,
             });
         }
 
@@ -391,6 +392,7 @@ impl DeviceDoc {
             received_report_hashes: ack_hash_list,
             lifecycle_updates: pending_updates,
             pending_job_runs,
+            iroh_supported: false,
         };
         Ok(resp)
     }

--- a/m87-server/src/relay/relay_state.rs
+++ b/m87-server/src/relay/relay_state.rs
@@ -9,6 +9,7 @@ use tracing::{info, warn};
 pub struct RelayState {
     tunnels: Arc<RwLock<HashMap<String, Connection>>>,
     lost: Arc<RwLock<HashMap<String, ()>>>, // just a set, we don't need Instant
+    iroh_addrs: Arc<RwLock<HashMap<String, String>>>,
 }
 
 impl RelayState {
@@ -16,6 +17,7 @@ impl RelayState {
         Self {
             tunnels: Arc::new(RwLock::new(HashMap::new())),
             lost: Arc::new(RwLock::new(HashMap::new())),
+            iroh_addrs: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -55,6 +57,10 @@ impl RelayState {
                 // Mark device lost
                 let mut lost = self.lost.write().await;
                 lost.insert(device_short_id.to_string(), ());
+
+                // Clear iroh addr — device is no longer reachable
+                let mut iroh_addrs = self.iroh_addrs.write().await;
+                iroh_addrs.remove(device_short_id);
             } else {
                 warn!(
                     "Skipping removal for device {} because connection ID does not match (stale close event)",
@@ -75,6 +81,18 @@ impl RelayState {
         tunnels.contains_key(device_short_id)
     }
 
+    /// Upsert the iroh EndpointAddr (opaque JSON string) for a device.
+    pub async fn set_iroh_addr(&self, device_short_id: &str, addr: String) {
+        let mut iroh_addrs = self.iroh_addrs.write().await;
+        iroh_addrs.insert(device_short_id.to_string(), addr);
+    }
+
+    /// Return the stored iroh EndpointAddr for a device, if any.
+    pub async fn get_iroh_addr(&self, device_short_id: &str) -> Option<String> {
+        let iroh_addrs = self.iroh_addrs.read().await;
+        iroh_addrs.get(device_short_id).cloned()
+    }
+
     /// Return active (non-lost) tunnel
     pub async fn get_tunnel(&self, device_short_id: &str) -> Option<Connection> {
         let lost = self.lost.read().await;
@@ -84,5 +102,84 @@ impl RelayState {
 
         let tunnels = self.tunnels.read().await;
         tunnels.get(device_short_id).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── set_iroh_addr / get_iroh_addr ──────────────────────────────────────
+
+    /// get_iroh_addr returns None for an unknown device.
+    #[tokio::test]
+    async fn test_get_iroh_addr_unknown_device_returns_none() {
+        let state = RelayState::new();
+        assert_eq!(state.get_iroh_addr("ghost-device").await, None);
+    }
+
+    /// set_iroh_addr then get_iroh_addr returns the stored value.
+    #[tokio::test]
+    async fn test_set_then_get_iroh_addr() {
+        let state = RelayState::new();
+        state
+            .set_iroh_addr("dev1", "{\"direct\":[\"127.0.0.1:4000\"]}".to_string())
+            .await;
+        assert_eq!(
+            state.get_iroh_addr("dev1").await,
+            Some("{\"direct\":[\"127.0.0.1:4000\"]}".to_string())
+        );
+    }
+
+    /// set_iroh_addr is an upsert — calling it twice keeps the latest value.
+    #[tokio::test]
+    async fn test_set_iroh_addr_upserts() {
+        let state = RelayState::new();
+        state.set_iroh_addr("dev1", "addr-v1".to_string()).await;
+        state.set_iroh_addr("dev1", "addr-v2".to_string()).await;
+        assert_eq!(
+            state.get_iroh_addr("dev1").await,
+            Some("addr-v2".to_string())
+        );
+    }
+
+    /// Two different devices store independent values.
+    #[tokio::test]
+    async fn test_iroh_addrs_are_device_isolated() {
+        let state = RelayState::new();
+        state.set_iroh_addr("dev-a", "addr-a".to_string()).await;
+        state.set_iroh_addr("dev-b", "addr-b".to_string()).await;
+
+        assert_eq!(
+            state.get_iroh_addr("dev-a").await,
+            Some("addr-a".to_string())
+        );
+        assert_eq!(
+            state.get_iroh_addr("dev-b").await,
+            Some("addr-b".to_string())
+        );
+
+        // Clearing one device must not affect the other.
+        {
+            let mut addrs = state.iroh_addrs.write().await;
+            addrs.remove("dev-a");
+        }
+        assert_eq!(state.get_iroh_addr("dev-a").await, None);
+        assert_eq!(
+            state.get_iroh_addr("dev-b").await,
+            Some("addr-b".to_string()),
+            "dev-b should be unaffected"
+        );
+    }
+
+    /// RelayState is Clone; clones share the same underlying maps.
+    #[tokio::test]
+    async fn test_relay_state_clone_shares_iroh_addrs() {
+        let state = RelayState::new();
+        let clone = state.clone();
+
+        state.set_iroh_addr("dev1", "addr1".to_string()).await;
+        // The clone should see the same data immediately.
+        assert_eq!(clone.get_iroh_addr("dev1").await, Some("addr1".to_string()));
     }
 }

--- a/m87-server/src/util/app_state.rs
+++ b/m87-server/src/util/app_state.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use m87_shared::iroh_ticket::IrohTicketSigner;
+
 use crate::{config::AppConfig, db::Mongo, relay::relay_state::RelayState};
 
 #[derive(Clone)]
@@ -7,4 +9,8 @@ pub struct AppState {
     pub db: Arc<Mongo>,
     pub config: Arc<AppConfig>,
     pub relay: Arc<RelayState>,
+    /// Signs short-lived tickets authorizing direct CLI→device iroh
+    /// connections. The matching public key is advertised to devices in the
+    /// heartbeat so they can verify the tickets CLIs present.
+    pub iroh_ticket_signer: Arc<IrohTicketSigner>,
 }

--- a/m87-shared/Cargo.toml
+++ b/m87-shared/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 hex = "0.4"
 uuid = { version = "1.19", features = ["v4"] }
+ed25519-dalek = "2.2"
+base64 = { workspace = true }
+getrandom = "0.2"

--- a/m87-shared/src/heartbeat.rs
+++ b/m87-shared/src/heartbeat.rs
@@ -22,9 +22,12 @@ pub struct HeartbeatRequest {
     /// `2`         = new format (`services` / `observers` / `job_defs`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supported_revision_format: Option<u8>,
+    /// iroh `EndpointAddr` (JSON) advertised by the device for direct P2P.
+    #[serde(default)]
+    pub iroh_node_addr: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct HeartbeatResponse {
     pub up_to_date: bool,
     #[serde(default)]
@@ -43,4 +46,73 @@ pub struct HeartbeatResponse {
     /// Job runs that are `Queued` and waiting to be executed on this device.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pending_job_runs: Vec<JobRun>,
+    /// Whether the server-side relay understands iroh signalling.
+    #[serde(default)]
+    pub iroh_supported: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── HeartbeatRequest backward-compat ────────────────────────────────────
+
+    /// A payload produced by an *old* client (no iroh_node_addr field) must
+    /// still deserialise cleanly; the new field should default to None.
+    #[test]
+    fn test_request_missing_iroh_addr_defaults_to_none() {
+        let old_json = r#"{
+            "last_instruction_hash": "abc",
+            "active_revision": "rev1"
+        }"#;
+        let req: HeartbeatRequest = serde_json::from_str(old_json).unwrap();
+        assert_eq!(req.iroh_node_addr, None);
+        assert_eq!(req.last_instruction_hash, "abc");
+    }
+
+    /// A new client that sets iroh_node_addr should round-trip cleanly.
+    #[test]
+    fn test_request_iroh_addr_round_trips() {
+        let original = HeartbeatRequest {
+            last_instruction_hash: "hash".into(),
+            active_revision: "rev".into(),
+            iroh_node_addr: Some("{\"nodeId\":\"test\"}".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: HeartbeatRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.iroh_node_addr, original.iroh_node_addr);
+    }
+
+    // ── HeartbeatResponse backward-compat ───────────────────────────────────
+
+    /// Old server responses (pre-iroh) must still deserialise; iroh_supported
+    /// should default to false so old devices aren't confused.
+    #[test]
+    fn test_response_missing_iroh_supported_defaults_false() {
+        let old_json = r#"{
+            "up_to_date": true,
+            "instruction_hash": "hash123"
+        }"#;
+        let resp: HeartbeatResponse = serde_json::from_str(old_json).unwrap();
+        assert!(
+            !resp.iroh_supported,
+            "iroh_supported should default to false"
+        );
+        assert!(resp.up_to_date);
+    }
+
+    /// A response that explicitly sets iroh_supported = true should round-trip.
+    #[test]
+    fn test_response_iroh_supported_round_trips() {
+        let original = HeartbeatResponse {
+            up_to_date: true,
+            instruction_hash: "hash".into(),
+            iroh_supported: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: HeartbeatResponse = serde_json::from_str(&json).unwrap();
+        assert!(decoded.iroh_supported);
+    }
 }

--- a/m87-shared/src/heartbeat.rs
+++ b/m87-shared/src/heartbeat.rs
@@ -49,6 +49,11 @@ pub struct HeartbeatResponse {
     /// Whether the server-side relay understands iroh signalling.
     #[serde(default)]
     pub iroh_supported: bool,
+    /// base64 Ed25519 public key the server signs iroh connection tickets with.
+    /// The device caches this and uses it to verify tickets that CLIs present
+    /// on direct iroh connections. `None` from servers that predate the feature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iroh_ticket_pubkey: Option<String>,
 }
 
 #[cfg(test)]

--- a/m87-shared/src/iroh_ticket.rs
+++ b/m87-shared/src/iroh_ticket.rs
@@ -1,0 +1,255 @@
+//! Server-brokered authorization tickets for direct iroh connections.
+//!
+//! iroh authenticates the *transport* cryptographically (each endpoint has a
+//! node keypair), but it knows nothing about m87 *authorization* — "is this
+//! user allowed to control this device?". Over the server relay the server
+//! answers that and the device simply trusts the relayed stream. A direct
+//! CLI→device iroh connection has no server in the middle, so the device needs
+//! an equivalent server-vouched proof.
+//!
+//! An [`IrohTicket`] is that proof: the server (which already authenticated the
+//! CLI and enforced access) signs a short-lived ticket pinned to one device.
+//! The device verifies the server's Ed25519 signature — it never re-checks the
+//! CLI's credentials, so this works for any caller the server accepts (OAuth
+//! users *and* API keys). The device learns the server's public key over its
+//! existing, already-trusted heartbeat channel.
+
+use base64::{Engine, engine::general_purpose::STANDARD as B64};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Authorization payload granting a CLI the right to open a direct iroh
+/// connection to one specific device for a short window.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IrohTicket {
+    /// Short id of the device this ticket authorizes. Pins the ticket to one
+    /// device so it cannot be replayed against another.
+    pub device_short_id: String,
+    /// Identity the server authenticated (email / sub / org id). Informational
+    /// and for audit — authorization was already enforced at issue time.
+    pub subject: String,
+    /// Issue time (unix ms).
+    pub issued_at_ms: u64,
+    /// Expiry (unix ms). Keep short; the CLI fetches a fresh ticket per connect.
+    pub expires_at_ms: u64,
+}
+
+/// A signed envelope: the exact payload bytes that were signed, plus the
+/// Ed25519 signature over them. Verification runs over the transmitted bytes,
+/// so no canonical-JSON dance is needed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedIrohTicket {
+    /// base64 of the JSON-serialized [`IrohTicket`].
+    pub payload: String,
+    /// base64 of the Ed25519 signature over the decoded `payload` bytes.
+    pub sig: String,
+}
+
+/// Why a ticket was rejected.
+#[derive(Debug)]
+pub enum TicketError {
+    /// Malformed base64 / JSON / key length.
+    Decode(String),
+    /// Signature did not verify against the expected key.
+    BadSignature,
+    /// `now` is past the ticket's expiry.
+    Expired,
+    /// Ticket was issued for a different device than the one verifying it.
+    WrongDevice { expected: String, got: String },
+}
+
+impl fmt::Display for TicketError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TicketError::Decode(e) => write!(f, "malformed iroh ticket: {e}"),
+            TicketError::BadSignature => write!(f, "iroh ticket signature did not verify"),
+            TicketError::Expired => write!(f, "iroh ticket expired"),
+            TicketError::WrongDevice { expected, got } => {
+                write!(f, "iroh ticket is for device {got}, not {expected}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TicketError {}
+
+impl SignedIrohTicket {
+    /// Verify the server signature, the device binding and the expiry, and
+    /// return the inner ticket on success.
+    pub fn verify(
+        &self,
+        verifying_key: &VerifyingKey,
+        expected_device_short_id: &str,
+        now_ms: u64,
+    ) -> Result<IrohTicket, TicketError> {
+        let payload = B64
+            .decode(self.payload.as_bytes())
+            .map_err(|e| TicketError::Decode(e.to_string()))?;
+        let sig_bytes = B64
+            .decode(self.sig.as_bytes())
+            .map_err(|e| TicketError::Decode(e.to_string()))?;
+        let sig = Signature::from_slice(&sig_bytes).map_err(|_| TicketError::BadSignature)?;
+
+        verifying_key
+            .verify(&payload, &sig)
+            .map_err(|_| TicketError::BadSignature)?;
+
+        let ticket: IrohTicket =
+            serde_json::from_slice(&payload).map_err(|e| TicketError::Decode(e.to_string()))?;
+
+        if ticket.device_short_id != expected_device_short_id {
+            return Err(TicketError::WrongDevice {
+                expected: expected_device_short_id.to_string(),
+                got: ticket.device_short_id,
+            });
+        }
+        if now_ms > ticket.expires_at_ms {
+            return Err(TicketError::Expired);
+        }
+        Ok(ticket)
+    }
+}
+
+/// Server-side signer. Holds the private signing key; the CLI never sees it.
+pub struct IrohTicketSigner {
+    key: SigningKey,
+}
+
+impl IrohTicketSigner {
+    /// Generate a fresh random signing key (dev / e2e; production should load a
+    /// fleet-wide key via [`from_seed_b64`](Self::from_seed_b64) so any server
+    /// instance signs tickets the device will trust).
+    pub fn generate() -> Self {
+        let mut seed = [0u8; 32];
+        getrandom::getrandom(&mut seed).expect("OS RNG must be available");
+        Self {
+            key: SigningKey::from_bytes(&seed),
+        }
+    }
+
+    /// Load a signing key from a base64-encoded 32-byte seed.
+    pub fn from_seed_b64(seed_b64: &str) -> Result<Self, TicketError> {
+        let bytes = B64
+            .decode(seed_b64.trim().as_bytes())
+            .map_err(|e| TicketError::Decode(e.to_string()))?;
+        let seed: [u8; 32] = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| TicketError::Decode("signing seed must be 32 bytes".into()))?;
+        Ok(Self {
+            key: SigningKey::from_bytes(&seed),
+        })
+    }
+
+    /// base64 of the 32-byte seed — for persisting / sharing the key.
+    pub fn seed_b64(&self) -> String {
+        B64.encode(self.key.to_bytes())
+    }
+
+    /// base64 of the public verifying key — advertised to devices.
+    pub fn public_b64(&self) -> String {
+        B64.encode(self.key.verifying_key().to_bytes())
+    }
+
+    /// Sign a ticket.
+    pub fn sign(&self, ticket: &IrohTicket) -> SignedIrohTicket {
+        let payload = serde_json::to_vec(ticket).expect("IrohTicket serializes");
+        let sig = self.key.sign(&payload);
+        SignedIrohTicket {
+            payload: B64.encode(&payload),
+            sig: B64.encode(sig.to_bytes()),
+        }
+    }
+}
+
+/// Parse a base64-encoded Ed25519 public key (as advertised in the heartbeat).
+pub fn verifying_key_from_b64(public_b64: &str) -> Result<VerifyingKey, TicketError> {
+    let bytes = B64
+        .decode(public_b64.trim().as_bytes())
+        .map_err(|e| TicketError::Decode(e.to_string()))?;
+    let arr: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| TicketError::Decode("public key must be 32 bytes".into()))?;
+    VerifyingKey::from_bytes(&arr).map_err(|_| TicketError::Decode("invalid public key".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ticket(device: &str, exp: u64) -> IrohTicket {
+        IrohTicket {
+            device_short_id: device.to_string(),
+            subject: "user@example.com".to_string(),
+            issued_at_ms: 1_000,
+            expires_at_ms: exp,
+        }
+    }
+
+    #[test]
+    fn round_trips_and_verifies() {
+        let signer = IrohTicketSigner::generate();
+        let vk = verifying_key_from_b64(&signer.public_b64()).unwrap();
+        let signed = signer.sign(&ticket("abc123", 10_000));
+
+        let out = signed.verify(&vk, "abc123", 5_000).unwrap();
+        assert_eq!(out.device_short_id, "abc123");
+        assert_eq!(out.subject, "user@example.com");
+    }
+
+    #[test]
+    fn rejects_expired() {
+        let signer = IrohTicketSigner::generate();
+        let vk = verifying_key_from_b64(&signer.public_b64()).unwrap();
+        let signed = signer.sign(&ticket("abc123", 10_000));
+        assert!(matches!(
+            signed.verify(&vk, "abc123", 10_001),
+            Err(TicketError::Expired)
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_device() {
+        let signer = IrohTicketSigner::generate();
+        let vk = verifying_key_from_b64(&signer.public_b64()).unwrap();
+        let signed = signer.sign(&ticket("abc123", 10_000));
+        assert!(matches!(
+            signed.verify(&vk, "other", 5_000),
+            Err(TicketError::WrongDevice { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_signature_from_another_key() {
+        let signer = IrohTicketSigner::generate();
+        let attacker = IrohTicketSigner::generate();
+        let attacker_vk = verifying_key_from_b64(&attacker.public_b64()).unwrap();
+        let signed = signer.sign(&ticket("abc123", 10_000));
+        assert!(matches!(
+            signed.verify(&attacker_vk, "abc123", 5_000),
+            Err(TicketError::BadSignature)
+        ));
+    }
+
+    #[test]
+    fn rejects_tampered_payload() {
+        let signer = IrohTicketSigner::generate();
+        let vk = verifying_key_from_b64(&signer.public_b64()).unwrap();
+        let mut signed = signer.sign(&ticket("abc123", 10_000));
+        // Swap the payload for a different device while keeping the old sig.
+        signed.payload = B64.encode(serde_json::to_vec(&ticket("evil", 10_000)).unwrap());
+        assert!(matches!(
+            signed.verify(&vk, "evil", 5_000),
+            Err(TicketError::BadSignature)
+        ));
+    }
+
+    #[test]
+    fn seed_b64_round_trips() {
+        let signer = IrohTicketSigner::generate();
+        let restored = IrohTicketSigner::from_seed_b64(&signer.seed_b64()).unwrap();
+        assert_eq!(signer.public_b64(), restored.public_b64());
+    }
+}

--- a/m87-shared/src/lib.rs
+++ b/m87-shared/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod deploy_spec;
 pub mod device;
 pub mod heartbeat;
+pub mod iroh_ticket;
 pub mod metrics;
 pub mod org;
 pub mod pagination;

--- a/tests/src/e2e_containers/containers.rs
+++ b/tests/src/e2e_containers/containers.rs
@@ -310,6 +310,20 @@ impl E2EInfra {
         Ok(())
     }
 
+    /// Base URL for reaching the server's HTTP API from the host (test side).
+    /// The server's in-container 8084 port is published to an ephemeral host
+    /// port; tests use this to call server endpoints directly with reqwest.
+    pub async fn server_base_url(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let port = self.server.get_host_port_ipv4(8084).await?;
+        Ok(format!("https://localhost:{}", port))
+    }
+
+    /// The admin API key seeded into the CLI credentials and trusted by the
+    /// server (`M87_API_KEY`). Usable as a `Bearer` token for direct API calls.
+    pub fn admin_key() -> &'static str {
+        ADMIN_KEY
+    }
+
     /// Execute a CLI command and return the output
     pub async fn cli_exec(&self, args: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
         let cmd = format!("m87 {} --verbose", args.join(" "));

--- a/tests/src/e2e_containers/install.rs
+++ b/tests/src/e2e_containers/install.rs
@@ -129,7 +129,7 @@ async fn copy_file_between_containers(
 /// Infrastructure for install script tests
 struct InstallTestInfra {
     container: ContainerAsync<GenericImage>,
-    /// Container to extract the binary from (m87-client:latest)
+    /// Container to extract the `m87` binary from (the e2e client image).
     binary_source: ContainerAsync<GenericImage>,
 }
 
@@ -142,14 +142,19 @@ impl InstallTestInfra {
         // Build the install-test image
         ensure_install_test_image().map_err(E2EError::Setup)?;
 
-        // Ensure m87-client:latest is built (need it to extract binary)
+        // Ensure the e2e images are built (we extract the `m87` binary from the
+        // e2e client image; the old prod `m87-client:latest` image is no longer
+        // built — see setup.rs).
         super::setup::ensure_images_built()
             .await
             .map_err(E2EError::Setup)?;
 
-        // Start a container from m87-client:latest to extract the binary
-        let binary_source = GenericImage::new("m87-client", "latest")
-            .with_entrypoint("sh")
+        // Start a container from the e2e client image to extract the binary.
+        let binary_source = GenericImage::new(
+            super::setup::CLIENT_IMAGE_NAME,
+            super::setup::CLIENT_IMAGE_TAG,
+        )
+        .with_entrypoint("sh")
             .with_cmd(vec!["-c", "sleep infinity"])
             .start()
             .await

--- a/tests/src/e2e_containers/install.rs
+++ b/tests/src/e2e_containers/install.rs
@@ -283,8 +283,16 @@ impl InstallTestInfra {
         )
         .await?;
 
-        // Wait for server to start
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        // Poll until the server actually serves (a fixed sleep raced under CPU
+        // contention when running multiple stacks in parallel).
+        exec_shell(
+            &self.container,
+            "for i in $(seq 1 50); do \
+               curl -fsS -o /dev/null http://localhost:8000/install.sh && exit 0; \
+               sleep 0.2; \
+             done; echo 'http server did not become ready' >&2; exit 1",
+        )
+        .await?;
 
         Ok(())
     }

--- a/tests/src/e2e_containers/iroh_p2p.rs
+++ b/tests/src/e2e_containers/iroh_p2p.rs
@@ -20,7 +20,26 @@
 
 use super::E2EInfra;
 use super::fixtures::TestSetup;
-use super::helpers::{E2EError, WaitConfig, wait_for_result};
+use super::helpers::{E2EError, WaitConfig, exec_background, exec_shell, wait_for_result};
+
+/// Poll `exec` until it reports a direct iroh connection. Used as a readiness
+/// gate: once a command takes the iroh path, the device's addr is advertised
+/// and subsequent commands (e.g. forward) will take it too.
+async fn wait_until_iroh_ready(setup: &TestSetup) -> Result<(), E2EError> {
+    let dev = setup.device.name.clone();
+    wait_for_result(
+        WaitConfig::with_description("iroh data path to become ready"),
+        || {
+            let cli = &setup.infra.cli;
+            let cmd = format!("m87 {dev} exec -- true 2>&1");
+            async move {
+                let out = exec_shell(cli, &cmd).await?;
+                Ok(out.contains("via iroh").then_some(()))
+            }
+        },
+    )
+    .await
+}
 
 /// Once the runtime's control tunnel is up, the device heartbeats its iroh
 /// `EndpointAddr` and the server exposes it. Drive that path end-to-end.
@@ -29,10 +48,18 @@ async fn test_device_advertises_iroh_addr_via_heartbeat() -> Result<(), E2EError
     let setup = TestSetup::init().await?;
 
     // 1. The iroh-addr endpoint is keyed by the device ObjectId, not the
-    //    short id, so resolve it from the device list.
-    let list_json = setup.m87_cmd("devices list --json").await?;
-    let parsed: serde_json::Value = serde_json::from_str(&list_json).map_err(|e| {
-        E2EError::Exec(format!("`devices list --json` was not valid JSON: {e}\n{list_json}"))
+    //    short id, so resolve it from the device list. The CLI is run with
+    //    `2>&1`, so debug log lines are prepended to the JSON — slice from the
+    //    first `{` (the log lines contain no braces).
+    let list_out = setup.m87_cmd("devices list --json").await?;
+    let json_str = list_out
+        .find('{')
+        .map(|i| &list_out[i..])
+        .ok_or_else(|| {
+            E2EError::Exec(format!("no JSON object in `devices list --json` output:\n{list_out}"))
+        })?;
+    let parsed: serde_json::Value = serde_json::from_str(json_str).map_err(|e| {
+        E2EError::Exec(format!("`devices list --json` was not valid JSON: {e}\n{json_str}"))
     })?;
     let device_id = parsed["devices"]
         .as_array()
@@ -44,7 +71,7 @@ async fn test_device_advertises_iroh_addr_via_heartbeat() -> Result<(), E2EError
         .and_then(|d| d["id"].as_str())
         .ok_or_else(|| {
             E2EError::Exec(format!(
-                "device {} not found in `devices list --json`: {list_json}",
+                "device {} not found in `devices list --json`: {json_str}",
                 setup.device.short_id
             ))
         })?
@@ -118,5 +145,145 @@ async fn test_device_advertises_iroh_addr_via_heartbeat() -> Result<(), E2EError
     );
 
     tracing::info!("iroh addr signalling test passed: {addr_json}");
+    Ok(())
+}
+
+/// End-to-end data-plane test of the iroh layer and its relay fallback.
+///
+/// With the CLI dialer wired up, `m87 <device> exec` prefers a direct iroh
+/// connection. The CLI and runtime share the e2e Docker network, so the direct
+/// path should establish. The `M87_DISABLE_IROH` kill switch then forces the
+/// server relay, proving the fallback path. Both must run the command
+/// successfully. The chosen transport is asserted from `m87_client`'s debug log
+/// (`RUST_LOG=m87_client=debug` in the CLI container), captured via `2>&1`.
+#[tokio::test]
+async fn test_exec_over_iroh_and_relay_fallback() -> Result<(), E2EError> {
+    let setup = TestSetup::init().await?;
+    let dev = setup.device.name.clone();
+
+    // (a) Default path: iroh-preferred. Poll, because the device's iroh addr is
+    //     advertised on a heartbeat and may lag the control tunnel coming up;
+    //     until it lands, exec transparently uses the relay. We require it to
+    //     converge on the direct iroh path.
+    let iroh_out = wait_for_result(
+        WaitConfig::with_description("exec to use a direct iroh connection"),
+        || {
+            let cli = &setup.infra.cli;
+            let cmd = format!("m87 {dev} exec -- echo iroh-hello 2>&1");
+            async move {
+                let out = exec_shell(cli, &cmd).await?;
+                if !out.contains("iroh-hello") {
+                    return Err(E2EError::Exec(format!("exec did not run command:\n{out}")));
+                }
+                // Converged once the direct path is chosen; otherwise keep polling.
+                Ok(out.contains("via iroh").then_some(out))
+            }
+        },
+    )
+    .await?;
+    assert!(
+        iroh_out.contains("iroh-hello") && iroh_out.contains("via iroh"),
+        "exec should run over a direct iroh connection:\n{iroh_out}"
+    );
+
+    // (b) Kill switch forces the server relay. The same command must still work,
+    //     and must NOT take the iroh path. This is deterministic — single shot.
+    let relay_out = exec_shell(
+        &setup.infra.cli,
+        &format!("M87_DISABLE_IROH=1 m87 {dev} exec -- echo relay-hello 2>&1"),
+    )
+    .await?;
+    assert!(
+        relay_out.contains("relay-hello"),
+        "exec over the relay (iroh disabled) must succeed:\n{relay_out}"
+    );
+    assert!(
+        relay_out.contains("via server relay"),
+        "with M87_DISABLE_IROH set, exec must fall back to the relay:\n{relay_out}"
+    );
+    assert!(
+        !relay_out.contains("via iroh"),
+        "M87_DISABLE_IROH must suppress the iroh attempt entirely:\n{relay_out}"
+    );
+
+    tracing::info!("iroh data-plane + relay fallback test passed");
+    Ok(())
+}
+
+/// UDP forwarding over a direct iroh connection. UDP rides on QUIC datagrams
+/// (per-connection on iroh, vs. multiplexed over the relay), so it has its own
+/// device-side plumbing worth exercising end-to-end.
+///
+/// Sends a datagram through `m87 <device> forward <local>:<remote>/udp` and
+/// asserts it arrives at a `nc -u` listener on the device, while the forward
+/// log confirms it took the direct iroh path.
+#[tokio::test]
+async fn test_udp_forward_over_iroh() -> Result<(), E2EError> {
+    let setup = TestSetup::init().await?;
+    let dev = setup.device.name.clone();
+
+    // Make sure iroh is the live path before forwarding (else it'd race into
+    // the relay fallback while the device's addr is still propagating).
+    wait_until_iroh_ready(&setup).await?;
+
+    // Device: a UDP listener that records the first datagram it receives.
+    // `-W 1` makes nc exit after one packet, flushing its (block-buffered)
+    // stdout. `exec_background` already redirects stdout to the log file, so we
+    // point that at the recv file directly and add no redirect of our own — an
+    // extra `> file` in the command would be overridden and swallow the payload.
+    exec_background(
+        &setup.infra.runtime,
+        "nc -u -l -p 9091 -W 1",
+        "/tmp/udp_recv.txt",
+    )
+    .await
+    .map_err(|e| E2EError::Exec(e.to_string()))?;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // CLI: forward local udp/9090 → device 127.0.0.1:9091.
+    exec_background(
+        &setup.infra.cli,
+        &format!("m87 {dev} forward 9090:127.0.0.1:9091/udp"),
+        "/tmp/udp_forward.log",
+    )
+    .await
+    .map_err(|e| E2EError::Exec(e.to_string()))?;
+
+    // Wait for the forward to come up, and confirm it chose the iroh transport.
+    let fwd_log = wait_for_result(
+        WaitConfig::with_description("udp forward to establish"),
+        || {
+            let cli = &setup.infra.cli;
+            async move {
+                let log = exec_shell(cli, "cat /tmp/udp_forward.log 2>/dev/null || true").await?;
+                Ok(log.contains("UDP forward:").then_some(log))
+            }
+        },
+    )
+    .await?;
+    assert!(
+        fwd_log.contains("via iroh"),
+        "UDP forward should run over a direct iroh connection:\n{fwd_log}"
+    );
+
+    // Send the datagram a few times through the local forwarded port, polling
+    // the device listener for it. UDP is unreliable and the first packet can be
+    // lost while the path warms up, so we retry rather than send once.
+    let marker = "UDP_OVER_IROH_4242";
+    wait_for_result(
+        WaitConfig::with_description("udp datagram to arrive on the device over iroh"),
+        || {
+            let cli = &setup.infra.cli;
+            let rt = &setup.infra.runtime;
+            async move {
+                exec_shell(cli, &format!("printf '{marker}' | nc -u -w1 127.0.0.1 9090")).await?;
+                let got = exec_shell(rt, "cat /tmp/udp_recv.txt 2>/dev/null || true").await?;
+                Ok(got.contains(marker).then_some(()))
+            }
+        },
+    )
+    .await?;
+
+    tracing::info!("UDP-over-iroh forward test passed");
     Ok(())
 }

--- a/tests/src/e2e_containers/iroh_p2p.rs
+++ b/tests/src/e2e_containers/iroh_p2p.rs
@@ -1,0 +1,122 @@
+//! iroh P2P signalling e2e tests.
+//!
+//! iroh runs as an opportunistic *direct* connection layer alongside the
+//! existing quinn server relay. For a CLI to ever attempt a direct connection
+//! it must first learn the device's iroh `EndpointAddr`, which the device
+//! advertises in every heartbeat and the server caches and re-serves at
+//! `GET /device/{id}/iroh-addr`.
+//!
+//! The unit tests cover the serialisation (`m87-shared`) and the relay-state
+//! cache (`m87-server`) in isolation. This e2e test drives the whole
+//! signalling path through real containers:
+//!
+//!   runtime control tunnel → heartbeat(iroh_node_addr) → server relay_state
+//!     → GET /device/{id}/iroh-addr
+//!
+//! and asserts the advertised address is retrievable. It does not assert that
+//! a direct hole-punched connection succeeds (that depends on the CI network
+//! topology and the n0 relay); the relay fallback path is what the other e2e
+//! tests already exercise.
+
+use super::E2EInfra;
+use super::fixtures::TestSetup;
+use super::helpers::{E2EError, WaitConfig, wait_for_result};
+
+/// Once the runtime's control tunnel is up, the device heartbeats its iroh
+/// `EndpointAddr` and the server exposes it. Drive that path end-to-end.
+#[tokio::test]
+async fn test_device_advertises_iroh_addr_via_heartbeat() -> Result<(), E2EError> {
+    let setup = TestSetup::init().await?;
+
+    // 1. The iroh-addr endpoint is keyed by the device ObjectId, not the
+    //    short id, so resolve it from the device list.
+    let list_json = setup.m87_cmd("devices list --json").await?;
+    let parsed: serde_json::Value = serde_json::from_str(&list_json).map_err(|e| {
+        E2EError::Exec(format!("`devices list --json` was not valid JSON: {e}\n{list_json}"))
+    })?;
+    let device_id = parsed["devices"]
+        .as_array()
+        .and_then(|devices| {
+            devices
+                .iter()
+                .find(|d| d["short_id"] == setup.device.short_id)
+        })
+        .and_then(|d| d["id"].as_str())
+        .ok_or_else(|| {
+            E2EError::Exec(format!(
+                "device {} not found in `devices list --json`: {list_json}",
+                setup.device.short_id
+            ))
+        })?
+        .to_string();
+
+    // 2. Host-side HTTPS client. The e2e server uses a self-signed cert, same
+    //    as the readiness probe in `wait_for_server`.
+    let base = setup
+        .infra
+        .server_base_url()
+        .await
+        .map_err(|e| E2EError::Exec(e.to_string()))?;
+    let url = format!("{base}/device/{device_id}/iroh-addr");
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .http1_only()
+        .build()
+        .map_err(|e| E2EError::Exec(e.to_string()))?;
+
+    // 3. Poll until the device has heartbeated its addr. A 404 ("iroh not
+    //    available") just means no heartbeat has carried it yet — keep waiting.
+    //    The runtime waits up to 10s for iroh relay registration at startup
+    //    before the first heartbeat, so this can take ~15s.
+    let addr_json = wait_for_result(
+        WaitConfig::with_description("device to advertise its iroh addr"),
+        || async {
+            let resp = client
+                .get(&url)
+                .bearer_auth(E2EInfra::admin_key())
+                .timeout(std::time::Duration::from_secs(5))
+                .send()
+                .await
+                .map_err(|e| E2EError::Exec(e.to_string()))?;
+
+            if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            if !resp.status().is_success() {
+                return Err(E2EError::Exec(format!(
+                    "iroh-addr endpoint returned HTTP {}",
+                    resp.status()
+                )));
+            }
+
+            let text = resp
+                .text()
+                .await
+                .map_err(|e| E2EError::Exec(e.to_string()))?;
+            let body: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| E2EError::Exec(format!("iroh-addr body not JSON: {e}\n{text}")))?;
+            Ok(body["iroh_node_addr"].as_str().map(str::to_string))
+        },
+    )
+    .await?;
+
+    // 4. The stored value is the device's serialised iroh `EndpointAddr`. It
+    //    must be a non-empty JSON object (carrying at least the node id) — that
+    //    proves the device produced a real addr, the server cached it, and the
+    //    API served it back. We avoid asserting an exact field name so the test
+    //    survives iroh version bumps.
+    assert!(
+        !addr_json.is_empty(),
+        "stored iroh addr should not be empty"
+    );
+    let addr: serde_json::Value = serde_json::from_str(&addr_json).map_err(|e| {
+        E2EError::Exec(format!("stored iroh addr is not valid JSON: {e}\n{addr_json}"))
+    })?;
+    assert!(
+        addr.is_object(),
+        "iroh addr should deserialise to a JSON object, got: {addr_json}"
+    );
+
+    tracing::info!("iroh addr signalling test passed: {addr_json}");
+    Ok(())
+}

--- a/tests/src/e2e_containers/mod.rs
+++ b/tests/src/e2e_containers/mod.rs
@@ -6,6 +6,7 @@ pub mod containers;
 mod deployment;
 mod device_registration;
 mod docker;
+mod iroh_p2p;
 mod logs_status;
 mod exec;
 pub mod fixtures;

--- a/tests/src/e2e_containers/setup.rs
+++ b/tests/src/e2e_containers/setup.rs
@@ -126,8 +126,32 @@ async fn build_e2e_image(
     std::fs::copy(workspace_root.join(dockerfile_rel), ctx_path.join("Dockerfile"))
         .map_err(|e| format!("Failed to stage {} into build context: {}", dockerfile_rel, e))?;
 
+    // `docker buildx build --load` so we can attach a layer cache. The base
+    // image + apt layer are stable across runs; only the final `COPY <binary>`
+    // layer changes, so caching skips the ~40s apt install every run. GitHub's
+    // Actions cache backend (`type=gha`) is only available inside a GHA runner
+    // with a `docker-container` buildx builder (set up by setup-buildx-action),
+    // so we add the cache flags only there; locally it's a plain buildx build.
+    let mut args: Vec<String> = vec![
+        "buildx".into(),
+        "build".into(),
+        "--load".into(),
+        "-t".into(),
+        image.into(),
+    ];
+    if std::env::var("GITHUB_ACTIONS").as_deref() == Ok("true") {
+        let scope = image.replace(':', "-");
+        args.push(format!("--cache-from=type=gha,scope={scope}"));
+        // ignore-error keeps a cache-export hiccup (e.g. missing token) from
+        // failing the whole image build.
+        args.push(format!(
+            "--cache-to=type=gha,scope={scope},mode=max,ignore-error=true"
+        ));
+    }
+    args.push(".".into());
+
     let status = Command::new("docker")
-        .args(["build", "-t", image, "."])
+        .args(&args)
         .current_dir(ctx_path)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/tests/src/e2e_containers/setup.rs
+++ b/tests/src/e2e_containers/setup.rs
@@ -34,113 +34,118 @@ async fn build_images() -> Result<(), String> {
         .map(|p| p.parent().map(|p| p.to_path_buf()).unwrap_or(p))
         .unwrap_or_else(|_| std::path::PathBuf::from(".."));
 
-    // Build server image
-    tracing::info!(
-        "Building {} (Docker cache will speed up if unchanged)...",
-        SERVER_IMAGE
-    );
-    let status = Command::new("docker")
-        .args([
-            "build",
-            "-t",
-            SERVER_IMAGE,
-            "-f",
-            "m87-server/Dockerfile",
-            "--build-arg",
-            "BUILD_PROFILE=release",
-            ".",
-        ])
-        .current_dir(&workspace_root)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .await;
+    // 1) Compile the binaries ONCE on the host, reusing the cargo `target/`
+    //    cache. This replaces two cold in-Docker release compiles (one per
+    //    image, recompiling the whole workspace) with a single incremental host
+    //    build. In CI these are already built by a prior workflow step, so this
+    //    is a fast up-to-date no-op; locally it just builds what's stale.
+    cargo_build(&workspace_root, &["build", "-p", "m87-server"], "m87-server").await?;
+    cargo_build(
+        &workspace_root,
+        &["build", "-p", "m87-client", "--features", "runtime,cli"],
+        "m87-client (m87)",
+    )
+    .await?;
 
-    match status {
-        Ok(s) if !s.success() => {
-            return Err(format!(
-                "Failed to build server image (exit code: {:?})",
-                s.code()
-            ));
-        }
-        Err(e) => {
-            return Err(format!("Failed to run docker build for server: {}", e));
-        }
-        _ => {
-            tracing::info!("Server image built successfully");
-        }
-    }
+    let debug_dir = workspace_root.join("target").join("debug");
+    let server_bin = debug_dir.join("m87-server");
+    let client_bin = debug_dir.join("m87");
 
-    // Build base client image first (m87-client:latest)
-    tracing::info!("Building m87-client:latest (base image)...");
-    let status = Command::new("docker")
-        .args([
-            "build",
-            "-t",
-            "m87-client:latest",
-            "-f",
-            "m87-client/Dockerfile",
-            "--build-arg",
-            "BUILD_PROFILE=release",
-            ".",
-        ])
-        .current_dir(&workspace_root)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .await;
-
-    match status {
-        Ok(s) if !s.success() => {
-            return Err(format!(
-                "Failed to build base client image (exit code: {:?})",
-                s.code()
-            ));
-        }
-        Err(e) => {
-            return Err(format!("Failed to run docker build for base client: {}", e));
-        }
-        _ => {
-            tracing::info!("Base client image built successfully");
-        }
-    }
-
-    // Build e2e client image (extends base with Docker CLI)
-    tracing::info!(
-        "Building {} (e2e image with Docker CLI)...",
-        CLIENT_IMAGE
-    );
-    let status = Command::new("docker")
-        .args([
-            "build",
-            "-t",
-            CLIENT_IMAGE,
-            "-f",
-            "m87-client/Dockerfile.e2e",
-            ".",
-        ])
-        .current_dir(&workspace_root)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .await;
-
-    match status {
-        Ok(s) if !s.success() => {
-            return Err(format!(
-                "Failed to build e2e client image (exit code: {:?})",
-                s.code()
-            ));
-        }
-        Err(e) => {
-            return Err(format!("Failed to run docker build for e2e client: {}", e));
-        }
-        _ => {
-            tracing::info!("E2E client image built successfully");
-        }
-    }
+    // 2) Stage each binary next to its slim COPY-only Dockerfile.e2e in a temp
+    //    build context and build the image. A temp context is required because
+    //    the repo `.dockerignore` excludes `target/`, so we cannot COPY the
+    //    binary from the workspace root.
+    build_e2e_image(
+        &workspace_root,
+        "m87-server/Dockerfile.e2e",
+        &server_bin,
+        "m87-server",
+        SERVER_IMAGE,
+    )
+    .await?;
+    build_e2e_image(
+        &workspace_root,
+        "m87-client/Dockerfile.e2e",
+        &client_bin,
+        "m87",
+        CLIENT_IMAGE,
+    )
+    .await?;
 
     Ok(())
+}
+
+/// Run `cargo <args>` from the workspace root (the `tests` crate is excluded
+/// from the workspace, so we build the members from the parent dir).
+async fn cargo_build(
+    workspace_root: &std::path::Path,
+    args: &[&str],
+    label: &str,
+) -> Result<(), String> {
+    tracing::info!("Host-building {} (reuses cargo target cache)...", label);
+    let status = Command::new("cargo")
+        .args(args)
+        .current_dir(workspace_root)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .await;
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => Err(format!(
+            "Host build of {} failed (exit code: {:?})",
+            label,
+            s.code()
+        )),
+        Err(e) => Err(format!("Failed to run cargo build for {}: {}", label, e)),
+    }
+}
+
+/// Stage `bin` (renamed to `bin_name`) alongside `dockerfile_rel` in a fresh
+/// temp context and `docker build` a slim COPY-only image tagged `image`.
+async fn build_e2e_image(
+    workspace_root: &std::path::Path,
+    dockerfile_rel: &str,
+    bin: &std::path::Path,
+    bin_name: &str,
+    image: &str,
+) -> Result<(), String> {
+    tracing::info!("Building {} (copy-only, host-built binary)...", image);
+
+    let ctx = tempfile::tempdir()
+        .map_err(|e| format!("Failed to create temp build context for {}: {}", image, e))?;
+    let ctx_path = ctx.path();
+
+    std::fs::copy(bin, ctx_path.join(bin_name)).map_err(|e| {
+        format!(
+            "Failed to stage binary {} into build context: {}",
+            bin.display(),
+            e
+        )
+    })?;
+    std::fs::copy(workspace_root.join(dockerfile_rel), ctx_path.join("Dockerfile"))
+        .map_err(|e| format!("Failed to stage {} into build context: {}", dockerfile_rel, e))?;
+
+    let status = Command::new("docker")
+        .args(["build", "-t", image, "."])
+        .current_dir(ctx_path)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .await;
+
+    match status {
+        Ok(s) if s.success() => {
+            tracing::info!("{} built successfully", image);
+            Ok(())
+        }
+        Ok(s) => Err(format!(
+            "Failed to build {} (exit code: {:?})",
+            image,
+            s.code()
+        )),
+        Err(e) => Err(format!("Failed to run docker build for {}: {}", image, e)),
+    }
 }
 
 /// Create Docker network for container communication (runs once per test run)


### PR DESCRIPTION
Closes https://github.com/make87/m87/issues/74

The server relay path is fully preserved. iroh runs in parallel as an opportunistic direct-connection layer.

## Architecture

  CLI --iroh--> (direct / iroh relay)  <--iroh-- Device runtime
    \                                                /
     \--quinn--> Server relay --quinn-->-----------

The server acts as the signalling channel (caches device iroh EndpointAddr) and permanent fallback (unchanged quinn relay).

## Changes

### m87-shared
- HeartbeatRequest: add iroh_node_addr: Option<String> (serde default)
- HeartbeatResponse: add iroh_supported: bool (serde default false)

### m87-server
- RelayState: iroh_addrs map (short_id -> EndpointAddr JSON); cleared when device tunnel is removed; set/get helpers
- quic.rs/run_heartbeat_loop: store iroh addr from each heartbeat
- device.rs: GET /device/{id}/iroh-addr (Role::Viewer)
- models/device.rs: populate iroh_supported in HeartbeatResponse

### m87-client
- Cargo.toml: iroh = 0.98
- streams/quic.rs: QuicRecvStream + QuicSendStream enums (Quinn|Iroh); QuicIo::from_quinn() and ::from_iroh(); relay path unchanged
- streams/stream_type.rs: from_incoming_stream() generic over impl AsyncRead + Unpin (transport-agnostic)
- streams/iroh_p2p.rs (new): IROH_ALPN, fetch_device_iroh_addr(), create_cli_iroh_endpoint(), try_iroh_connect(), open_iroh_stream(), try_open_iroh_stream() high-level fallback-safe helper
- device/control_tunnel.rs: bind iroh Endpoint (ALPN m87-iroh-p2p/1) at startup, wait up to 10s for relay registration, include EndpointAddr JSON in every HeartbeatRequest, parallel iroh accept loop with Auth0 JWKS token validation routing streams through the existing handle_incoming_stream router

## Tests (12 total, all passing)

m87-shared (4):
- test_request_missing_iroh_addr_defaults_to_none
- test_request_iroh_addr_round_trips
- test_response_missing_iroh_supported_defaults_false
- test_response_iroh_supported_round_trips

m87-server relay_state (5):
- test_get_iroh_addr_unknown_device_returns_none
- test_set_then_get_iroh_addr
- test_set_iroh_addr_upserts
- test_iroh_addrs_are_device_isolated
- test_relay_state_clone_shares_iroh_addrs

m87-client iroh_p2p (3):
- test_iroh_alpn_is_correct
- test_quic_io_from_iroh_roundtrip  <- real 2-endpoint iroh connection
- test_open_iroh_stream_framing     <- StreamType framing over iroh