### PR TITLE
Reliability and performance fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -143,14 +143,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -584,12 +584,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1249,7 +1243,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1388,7 +1382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1412,13 +1406,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.2",
+ "portable-atomic",
  "siphasher",
 ]
 
@@ -1707,11 +1701,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1965,7 +1961,7 @@ dependencies = [
  "hickory-proto",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "rand 0.10.1",
  "thiserror 2.0.17",
  "tinyvec",
@@ -1983,7 +1979,7 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
@@ -2006,7 +2002,7 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "moka",
  "ndk-context",
  "once_cell",
@@ -2474,22 +2470,6 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.0",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2497,7 +2477,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.17",
@@ -2517,12 +2497,6 @@ dependencies = [
  "simd_cesu8",
  "syn 2.0.111",
 ]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jni-sys"
@@ -3217,7 +3191,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3927,15 +3901,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3959,7 +3934,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4064,6 +4039,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ratatui"
@@ -4519,7 +4503,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4562,13 +4546,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.21.1",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -4578,7 +4562,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5366,7 +5350,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6293,7 +6277,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6485,15 +6469,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6535,21 +6510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6620,12 +6580,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6644,12 +6598,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6665,12 +6613,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6704,12 +6646,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6725,12 +6661,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6752,12 +6682,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6773,12 +6697,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/deny.toml
+++ b/deny.toml
@@ -111,6 +111,25 @@ reason = "Pulled via russh's libcrux-ml-kem 0.0.4 (post-quantum KEX). Fix requir
 id = "RUSTSEC-2026-0173" # proc-macro-error2 unmaintained
 reason = "Build-time-only proc-macro, pulled via russh's libcrux-ml-kem -> hax-lib-macros. No runtime or security impact. Will clear when russh (and its libcrux deps) upgrade past the libc pin."
 
+# --- rmcp: not reachable, we only use the stdio transport ---
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0189" # rmcp: DNS rebinding in Streamable HTTP server transport
+reason = "m87-client exposes MCP over the stdio transport only (rmcp::transport::io::stdio() in src/mcp/mod.rs). The advisory explicitly states non-HTTP transports (stdio/child-process) are not affected; the vulnerable Streamable HTTP server transport is never instantiated. The fix is an rmcp 0.16 -> 1.4+ major bump; will adopt when we upgrade rmcp."
+
+# --- quick-xml: transitive via self_update, not run on untrusted XML ---
+# self_update pulls quick-xml for its S3 (XML) backend. m87-client's updater
+# uses the GitHub-releases backend and parses the release JSON with our own
+# serde types (src/update/mod.rs), so the vulnerable quick-xml attribute /
+# NsReader paths are never fed attacker-controlled XML. No stable self_update
+# moves off quick-xml 0.38 yet (fix is >=0.41); both clear when it does.
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0194" # quick-xml: quadratic duplicate-attribute-name check (CPU DoS)
+reason = "Transitive via self_update's S3 XML backend, which m87-client does not use (updates come from GitHub releases parsed as JSON in src/update/mod.rs). Not run on untrusted XML. Blocked on self_update adopting quick-xml >=0.41."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0195" # quick-xml: unbounded NsReader namespace-declaration allocation (mem DoS)
+reason = "Same transitive self_update path as RUSTSEC-2026-0194; m87-client uses the GitHub (JSON) update backend, not the S3 XML backend, so NsReader never parses untrusted XML. Blocked on self_update adopting quick-xml >=0.41."
+
 
 [licenses]
 # List of explicitly allowed licenses

--- a/m87-client/src/device/deployment_manager.rs
+++ b/m87-client/src/device/deployment_manager.rs
@@ -812,13 +812,20 @@ impl DeploymentManager {
             start_map.insert(s.id.clone(), s);
         }
 
-        // Phase 2a: stop first
+        // Phase 2a: stop first. A failing stop step must NOT be silently
+        // swallowed — it leaves a half-torn-down unit. Record the failure so the
+        // service stays dirty (and is retried) and the error is surfaced to the
+        // caller, rather than reconcile reporting success.
+        let mut failed_hashes: HashSet<String> = HashSet::new();
         for (_, spec) in &stop_map {
             let wd = self
                 .resolve_workdir_for(&spec.id, spec.workdir.as_ref())
                 .await?;
             let rev = prev_rev.clone().unwrap_or_else(|| desired_rev.clone());
-            let _ = self.stop_service(spec, &rev, &wd).await;
+            if let Err(e) = self.stop_service(spec, &rev, &wd).await {
+                tracing::error!("stop_service for '{}' failed: {e:#}", spec.id);
+                failed_hashes.insert(spec.get_hash());
+            }
         }
 
         // Phase 2b: start
@@ -829,10 +836,21 @@ impl DeploymentManager {
             self.apply_service(spec, &desired_rev, &wd).await?;
         }
 
-        // Clear processed hashes
+        // Clear processed hashes, but keep any whose stop failed so it is retried
+        // on the next reconcile instead of being dropped.
         let mut ds = self.dirty_services.write().await;
         for h in dirty_hashes {
-            ds.remove(&h);
+            if !failed_hashes.contains(&h) {
+                ds.remove(&h);
+            }
+        }
+        drop(ds);
+
+        if !failed_hashes.is_empty() {
+            return Err(anyhow!(
+                "{} stop step(s) failed during reconcile",
+                failed_hashes.len()
+            ));
         }
 
         Ok(())
@@ -1808,6 +1826,41 @@ mod tests {
         mgr.set_desired_units(v2, vec![]).await?;
         mgr.reconcile_dirty().await?;
         assert!(!marker.exists(), "stop cmd should have removed marker");
+        Ok(())
+    }
+
+    // Reproduces the reporting/handling gap on the teardown path (Fix 2).
+    //
+    // When a service is removed from the desired revision, reconcile runs its
+    // stop steps. Today the stop is invoked as `let _ = self.stop_service(...)`
+    // (reconcile_dirty), so a FAILING stop step is silently discarded: reconcile
+    // returns Ok and clears the dirty flag, leaving a half-torn-down unit with no
+    // error surfaced and no retry. A failing stop must not be swallowed.
+    #[tokio::test]
+    async fn failed_stop_step_is_not_silently_swallowed() -> Result<()> {
+        let td = TempDir::new()?;
+        let mgr = make_mgr(&td).await;
+
+        // Service whose stop step always fails.
+        let v1 = mk_rev(
+            "r1",
+            vec![mk_svc("svc", sh("true"), sh("exit 1"))],
+            vec![],
+            vec![],
+        );
+        mgr.set_desired_units(v1, vec![]).await?;
+        mgr.reconcile_dirty().await?;
+
+        // Remove the service → its (failing) stop steps get scheduled.
+        let v2 = mk_rev("r2", vec![], vec![], vec![]);
+        mgr.set_desired_units(v2, vec![]).await?;
+
+        let res = mgr.reconcile_dirty().await;
+        assert!(
+            res.is_err(),
+            "a failing stop step must surface as an error from reconcile, not be \
+             swallowed by `let _ = stop_service(...)`"
+        );
         Ok(())
     }
 

--- a/m87-client/src/device/deployment_manager.rs
+++ b/m87-client/src/device/deployment_manager.rs
@@ -189,7 +189,7 @@ impl ObserveKind {
 
     fn decide_on_error(
         &self,
-        _st: &LocalRunState,
+        st: &LocalRunState,
         hooks: &ObserveHooks,
         consecutive: u32,
     ) -> ObserveDecision {
@@ -200,9 +200,25 @@ impl ObserveKind {
         } else {
             consecutive / fails_after
         };
+        // Edge-trigger the report: only emit on a healthy -> unhealthy
+        // transition, not on every `fails_after`-th consecutive failure. Once
+        // we've reported the unit unhealthy we stay silent until it recovers
+        // (the success path is likewise edge-triggered). Without this, a
+        // persistently-failing observe — e.g. an error line stuck inside a
+        // `logs --tail | grep` health check — re-enqueues a fresh RunState
+        // every `fails_after * every` seconds for as long as the line stays in
+        // the window. Because each RunState carries a unique `report_time` +
+        // `log_tail`, the `enqueue_event` content-hash dedup can't collapse
+        // them, so the pending-event queue grows unbounded and the 40/s drain
+        // pins a core. `is_failure`/`consecutive` are left untouched so the
+        // restart policy still fires on its own cadence.
+        let previously_healthy = match self {
+            ObserveKind::Liveness => !st.reported_alive_once || st.last_alive,
+            ObserveKind::Health => !st.reported_health_once || st.last_health,
+        };
         ObserveDecision {
             is_failure,
-            needs_send: is_failure,
+            needs_send: is_failure && previously_healthy,
             consecutive: consecutive_out,
         }
     }
@@ -2375,6 +2391,130 @@ mod tests {
         .await?;
         mgr.reconcile_dirty().await?;
         assert!(!marker.exists(), "stop should have run");
+        Ok(())
+    }
+
+    // ── Observe reporting: edge-trigger / anti-spam ──────────────────────────
+    //
+    // Regression guard for the heartbeat-spam + CPU-spike bug: a persistently
+    // unhealthy observe (e.g. an error line stuck in a `logs | grep` health
+    // check) must report the unhealthy state ONCE per healthy->unhealthy
+    // transition — not on every failing poll. Before the fix the failure
+    // branch of `decide_on_error` was level-triggered (`needs_send = is_failure`),
+    // so it re-enqueued a fresh RunState every `fails_after`-th failure forever;
+    // each carried a unique `report_time`/`log_tail` so the content-hash dedup
+    // in `enqueue_event` never collapsed them and the pending queue grew
+    // without bound.
+
+    fn failing_health_hooks(fails_after: Option<u32>) -> ObserveHooks {
+        ObserveHooks {
+            every: Duration::from_secs(10),
+            observe: sh("exit 1"),
+            observe_timeout: None,
+            record: None,
+            record_timeout: None,
+            report: None,
+            report_timeout: None,
+            fails_after,
+        }
+    }
+
+    fn healthy_health_hooks(fails_after: Option<u32>) -> ObserveHooks {
+        ObserveHooks {
+            observe: sh("true"),
+            ..failing_health_hooks(fails_after)
+        }
+    }
+
+    /// Drain every pending event and return the RunState reports in order.
+    async fn drain_runstates(mgr: &DeploymentManager) -> Vec<RunState> {
+        let mut out = Vec::new();
+        while let Some(ev) = claim_next_event(Some(mgr.root_dir.clone())).await.unwrap() {
+            if let DeployReportKind::RunState(rs) = ev.report {
+                out.push(rs);
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn health_persistently_unhealthy_reports_once_not_per_poll() -> Result<()> {
+        let td = TempDir::new()?;
+        let mgr = make_mgr(&td).await;
+        let spec = mk_observer_spec("obs");
+        let hooks = failing_health_hooks(Some(1));
+
+        // Simulate 5 consecutive failing health polls of the same service.
+        for _ in 0..5 {
+            mgr.run_observe(ObserveKind::Health, "run1", "r1", &spec, &hooks)
+                .await?;
+        }
+
+        let states = drain_runstates(&mgr).await;
+        let unhealthy = states.iter().filter(|s| s.healthy == Some(false)).count();
+        assert_eq!(
+            unhealthy, 1,
+            "a persistently unhealthy service must report exactly once, \
+             not once per poll (was {unhealthy}, i.e. one per failing poll pre-fix)"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn health_reports_once_across_fails_after_threshold() -> Result<()> {
+        // Mirrors the default compose template (`fails_after: 3`): the state
+        // crosses the threshold at poll 3, 6, 9. Pre-fix that emitted 3 reports;
+        // post-fix only the first (the healthy->unhealthy transition) is sent.
+        let td = TempDir::new()?;
+        let mgr = make_mgr(&td).await;
+        let spec = mk_observer_spec("obs");
+        let hooks = failing_health_hooks(Some(3));
+
+        for _ in 0..9 {
+            mgr.run_observe(ObserveKind::Health, "run1", "r1", &spec, &hooks)
+                .await?;
+        }
+
+        let states = drain_runstates(&mgr).await;
+        let unhealthy = states.iter().filter(|s| s.healthy == Some(false)).count();
+        assert_eq!(
+            unhealthy, 1,
+            "unhealthy state must be reported once at the threshold crossing, \
+             not on every `fails_after`-th failure (was {unhealthy} pre-fix)"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn health_recovery_rearms_unhealthy_reporting() -> Result<()> {
+        // The edge-trigger must work in both directions: unhealthy -> healthy
+        // re-arms the reporter so the next healthy -> unhealthy transition is
+        // reported again. Otherwise we'd go silent forever after the first flap.
+        let td = TempDir::new()?;
+        let mgr = make_mgr(&td).await;
+        let spec = mk_observer_spec("obs");
+        let failing = failing_health_hooks(Some(1));
+        let ok = healthy_health_hooks(Some(1));
+
+        // unhealthy burst -> 1 unhealthy report
+        for _ in 0..3 {
+            mgr.run_observe(ObserveKind::Health, "run1", "r1", &spec, &failing)
+                .await?;
+        }
+        // recover -> 1 healthy report
+        mgr.run_observe(ObserveKind::Health, "run1", "r1", &spec, &ok)
+            .await?;
+        // unhealthy again -> another unhealthy report
+        for _ in 0..3 {
+            mgr.run_observe(ObserveKind::Health, "run1", "r1", &spec, &failing)
+                .await?;
+        }
+
+        let states = drain_runstates(&mgr).await;
+        let unhealthy = states.iter().filter(|s| s.healthy == Some(false)).count();
+        let healthy = states.iter().filter(|s| s.healthy == Some(true)).count();
+        assert_eq!(unhealthy, 2, "each unhealthy transition should report once");
+        assert_eq!(healthy, 1, "the recovery should report once");
         Ok(())
     }
 }

--- a/m87-client/src/device/deployment_manager.rs
+++ b/m87-client/src/device/deployment_manager.rs
@@ -284,24 +284,41 @@ impl RevisionStore {
     }
 
     pub fn get_previous_config(dir_path: Option<PathBuf>) -> Result<Option<DeploymentRevision>> {
-        let path = Self::previous_path(dir_path)?;
-        if !path.exists() {
-            return Ok(None);
-        }
-        let s = std::fs::read_to_string(&path).context("read previous_units.json")?;
-        let c: DeploymentRevision =
-            serde_json::from_str(&s).context("parse previous_units.json")?;
-        Ok(Some(c))
+        Self::read_revision_file(&Self::previous_path(dir_path)?)
     }
 
     pub fn get_desired_config(dir_path: Option<PathBuf>) -> Result<Option<DeploymentRevision>> {
-        let path = Self::desired_path(dir_path)?;
+        Self::read_revision_file(&Self::desired_path(dir_path)?)
+    }
+
+    /// Read and parse a stored revision file. A corrupt or incompatible-schema
+    /// file (e.g. written by an older client) is NOT propagated as an error —
+    /// that would wedge every reconcile cycle forever, forcing a manual file
+    /// deletion. Instead we quarantine the bad file (`<name>.corrupt`) and
+    /// return `None`, so the loop makes progress and the server can re-push a
+    /// fresh revision on the next heartbeat.
+    fn read_revision_file(path: &Path) -> Result<Option<DeploymentRevision>> {
         if !path.exists() {
             return Ok(None);
         }
-        let s = std::fs::read_to_string(&path).context("read desired_units.json")?;
-        let c: DeploymentRevision = serde_json::from_str(&s).context("parse desired_units.json")?;
-        Ok(Some(c))
+        let s = std::fs::read_to_string(path)
+            .with_context(|| format!("read {}", path.display()))?;
+        match serde_json::from_str::<DeploymentRevision>(&s) {
+            Ok(c) => Ok(Some(c)),
+            Err(e) => {
+                let quarantine = path.with_file_name(format!(
+                    "{}.corrupt",
+                    path.file_name().and_then(|n| n.to_str()).unwrap_or("revision")
+                ));
+                tracing::warn!(
+                    "failed to parse {}, quarantining to {} and continuing: {e}",
+                    path.display(),
+                    quarantine.display()
+                );
+                let _ = std::fs::rename(path, &quarantine);
+                Ok(None)
+            }
+        }
     }
 
     /// Write a new desired config, backing up the current one to previous.
@@ -1496,14 +1513,20 @@ pub async fn claim_next_event(dir_path: Option<PathBuf>) -> Result<Option<Claime
         }
         let s = match fs::read_to_string(&dst).await {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(e) => {
+                // Unreadable / non-UTF-8 event: drop it rather than leaving it
+                // to be replayed from inflight on every restart.
+                tracing::warn!("failed to read event {dst:?}, removing: {e}");
+                let _ = fs::remove_file(&dst).await;
+                continue;
+            }
         };
         match serde_json::from_str::<DeployReportKind>(&s) {
             Ok(report) => {
                 return Ok(Some(ClaimedEvent { path: dst, report }));
             }
             Err(e) => {
-                tracing::warn!("failed to parse event: {e}");
+                tracing::warn!("failed to parse event {dst:?}, removing: {e}");
                 let _ = fs::remove_file(&dst).await;
             }
         }
@@ -2032,6 +2055,35 @@ mod tests {
 
         let loaded = RevisionStore::get_desired_config(Some(mgr.root_dir.clone()))?;
         assert!(loaded.unwrap().get_observer_map().is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn corrupt_desired_config_is_quarantined_not_stuck() -> Result<()> {
+        let td = TempDir::new()?;
+        let mgr = make_mgr(&td).await;
+        let root = mgr.root_dir.clone();
+
+        // Establish a valid desired config, then corrupt it on disk to simulate
+        // an old / incompatible-schema `desired_units.json`.
+        mgr.set_desired_units(mk_rev("r1", vec![], vec![], vec![]), vec![])
+            .await?;
+        let path = RevisionStore::desired_path(Some(root.clone()))?;
+        std::fs::write(&path, "{ not a valid DeploymentRevision")?;
+
+        // Must NOT return Err (that would wedge every reconcile cycle forever,
+        // requiring a manual file deletion). It recovers: returns None and moves
+        // the bad file aside so the server can re-push a fresh revision.
+        let loaded = RevisionStore::get_desired_config(Some(root.clone()))?;
+        assert!(loaded.is_none(), "corrupt config should read as None, not error");
+        assert!(!path.exists(), "corrupt config should be moved aside");
+        assert!(
+            path.with_file_name("desired_units.json.corrupt").exists(),
+            "corrupt config should be quarantined for inspection"
+        );
+
+        // A subsequent read is clean — no repeated error, file already handled.
+        assert!(RevisionStore::get_desired_config(Some(root))?.is_none());
         Ok(())
     }
 

--- a/m87-client/src/device/log_manager.rs
+++ b/m87-client/src/device/log_manager.rs
@@ -266,7 +266,11 @@ async fn spawn_follow(
                 }
                 res = lines.next_line() => {
                     match res {
-                        Ok(Some(line)) => tracing::info!("[observe]{}", format_log(&unit, &line, true)),
+                        Ok(Some(line)) => tracing::info!(
+                            target: "observe",
+                            "[observe]{}",
+                            format_log(&unit, &line, true)
+                        ),
                         Ok(None) => break, // EOF
                         Err(_) => break,   // I/O error; best-effort
                     }

--- a/m87-client/src/util/logging.rs
+++ b/m87-client/src/util/logging.rs
@@ -66,19 +66,46 @@ where
     }
 }
 
+fn make_filter(default_level: &str) -> EnvFilter {
+    EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(default_level))
+        .unwrap_or_else(|_| EnvFilter::new("info"))
+}
+
+/// Filter for the CLI log broadcast. Same base level as the console filter,
+/// but the `observe` target is always admitted at INFO so live follow logs
+/// reach the CLI regardless of the daemon's global level (`RUST_LOG`). Without
+/// this, running the daemon below INFO silently drops all `[observe]` lines.
+fn make_broadcast_filter(default_level: &str) -> EnvFilter {
+    make_filter(default_level)
+        .add_directive("observe=info".parse().expect("valid observe directive"))
+}
+
+/// Build the layered subscriber used by the daemon. Each layer carries its own
+/// filter (rather than a single global filter), so the broadcast layer can
+/// admit `observe` live-log events even when the console filter is below INFO.
+/// Extracted so it can be exercised in tests with a `with_default` scope
+/// instead of the global `.init()`.
+fn build_subscriber(
+    console_filter: EnvFilter,
+    broadcast_filter: EnvFilter,
+    tx: broadcast::Sender<String>,
+) -> impl Subscriber + Send + Sync + 'static {
+    tracing_subscriber::registry()
+        .with(tracing_fmt::layer().with_filter(console_filter))
+        .with(LogBroadcastLayer::new(tx).with_filter(broadcast_filter))
+}
+
 pub fn init_tracing_with_log_layer(default_level: &str) -> broadcast::Sender<String> {
     let (tx, _rx) = broadcast::channel(32_768);
     LOG_TX.set(tx.clone()).ok();
 
-    let filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new(default_level))
-        .unwrap_or_else(|_| EnvFilter::new("info"));
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(tracing_fmt::layer())
-        .with(LogBroadcastLayer::new(tx.clone()))
-        .init();
+    build_subscriber(
+        make_filter(default_level),
+        make_broadcast_filter(default_level),
+        tx.clone(),
+    )
+    .init();
 
     tx
 }
@@ -155,5 +182,53 @@ mod tests {
         assert_eq!(ts.len(), 8);
         assert_eq!(&ts[2..3], ":");
         assert_eq!(&ts[5..6], ":");
+    }
+
+    // ── Live-log broadcast gating ────────────────────────────────────────────
+    //
+    // Live `observe` follow logs are emitted as
+    // `tracing::info!(target: "observe", "[observe]…")` and carried to the CLI
+    // over the `LogBroadcastLayer`. That layer must NOT be gated by the
+    // daemon's global level: when the daemon runs below INFO (e.g.
+    // `RUST_LOG=warn`, or launched non-verbose) live logs must still flow,
+    // while health/liveness reports use a separate heartbeat path.
+
+    /// Control: the broadcast itself works — a WARN line passes the WARN filter
+    /// and reaches subscribers. Guards against the reproduce test below being a
+    /// false positive (i.e. the broadcast being broken for some other reason).
+    #[test]
+    fn warn_line_reaches_broadcast_under_warn_filter() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let subscriber =
+            build_subscriber(make_filter("warn"), make_broadcast_filter("warn"), tx.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!("noisy diagnostic");
+        });
+        let got = rx.try_recv();
+        assert!(got.is_ok(), "warn line should broadcast under warn filter");
+        assert!(got.unwrap().contains("noisy diagnostic"));
+    }
+
+    /// Regression: an `observe` live-log line (emitted at INFO, as the follow
+    /// loop does) must reach the CLI broadcast even when the daemon's global
+    /// level is `warn`. Fails without the per-layer `observe=info` broadcast
+    /// filter — that was the live-logs-missing bug.
+    #[test]
+    fn observe_line_reaches_broadcast_under_warn_filter() {
+        let (tx, mut rx) = broadcast::channel::<String>(16);
+        let subscriber =
+            build_subscriber(make_filter("warn"), make_broadcast_filter("warn"), tx.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            // Mirror the production follow emit in log_manager::spawn_follow.
+            tracing::info!(target: "observe", "[observe]hello from container");
+        });
+        let got = rx.try_recv();
+        assert!(
+            got.is_ok(),
+            "observe live-log line must reach the CLI broadcast even when the \
+             daemon's global level is `warn`; got {got:?} — this is the \
+             live-logs-missing bug"
+        );
+        assert!(got.unwrap().contains("hello from container"));
     }
 }

--- a/m87-server/src/auth/jwk.rs
+++ b/m87-server/src/auth/jwk.rs
@@ -9,6 +9,20 @@ use crate::{
     response::{ServerError, ServerResult},
 };
 
+/// Shared reqwest client with a request timeout. `reqwest` has no default
+/// timeout, so a hung IdP endpoint (JWKS / userinfo) would otherwise hang the
+/// auth task forever — these run on the QUIC/WebTransport paths which have no
+/// HTTP timeout layer. Reusing one client also keeps the connection/DNS pool.
+fn http_client() -> &'static Client {
+    static CLIENT: std::sync::OnceLock<Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("failed to build reqwest client")
+    })
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DecodedClaims {
     pub sub: String,
@@ -48,7 +62,7 @@ pub async fn validate_token(token: &str, config: &Arc<AppConfig>) -> ServerResul
         .kid
         .ok_or_else(|| ServerError::invalid_token("Token missing 'kid' field"))?;
 
-    let jwks: Jwks = Client::new()
+    let jwks: Jwks = http_client()
         .get(&jwks_url)
         .send()
         .await
@@ -83,7 +97,7 @@ pub async fn get_email_and_name_from_token(
     let issuer = config.oauth.issuer.trim_end_matches('/').to_string();
     let userinfo_url = format!("{}/userinfo", issuer);
 
-    let resp = Client::new()
+    let resp = http_client()
         .get(&userinfo_url)
         .bearer_auth(token)
         .send()

--- a/m87-server/src/db.rs
+++ b/m87-server/src/db.rs
@@ -25,6 +25,10 @@ impl Mongo {
     pub async fn connect(url: &str, db_name: &str) -> ServerResult<Self> {
         let mut opts = ClientOptions::parse(url).await?;
         opts.app_name = Some("nexus".into());
+        // The default max pool size (10) is easily saturated by the heartbeat
+        // ingestion path (several sequential DB ops per report). Raise it so a
+        // burst of reports can't starve every other request of a connection.
+        opts.max_pool_size = Some(50);
         let client = Client::with_options(opts)?;
         Ok(Self {
             client,
@@ -238,6 +242,14 @@ impl Mongo {
             )
             .await?;
 
+        // NON-partial index on {device_id, revision_id, created_at, _id}. Serves
+        // both the RunState-filtered failures aggregation AND the full-history
+        // snapshot / RunState-list reads, which filter {device_id, revision_id}
+        // WITHOUT a `kind.type` predicate and sort on `created_at`. This used to
+        // be partial on `kind.type: "RunState"`, which the unfiltered queries
+        // could not use — so they did a collection scan + blocking in-memory
+        // sort. (Must be a single index: two indexes with identical keys but
+        // different options are rejected by MongoDB.)
         self.deploy_reports()
             .create_index(
                 IndexModel::builder()
@@ -247,13 +259,27 @@ impl Mongo {
                         "created_at": -1,
                         "_id": -1
                     })
-                    .options(
-                        IndexOptions::builder()
-                            .partial_filter_expression(doc! { "kind.type": "RunState" })
-                            .build(),
-                    )
                     .build(),
             )
+            .await?;
+
+        // `get_by_revision_id` filters on `revision.id` alone.
+        self.deploy_revisions()
+            .create_index(IndexModel::builder().keys(doc! { "revision.id": 1 }).build())
+            .await?;
+
+        // `AuditLogDoc::list_for_device` filters `device_id` and sorts `timestamp` desc.
+        self.audit_logs()
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! { "device_id": 1, "timestamp": -1 })
+                    .build(),
+            )
+            .await?;
+
+        // User lookups by email (`{email}` and `{email: {$in}}`).
+        self.users()
+            .create_index(IndexModel::builder().keys(doc! { "email": 1 }).build())
             .await?;
 
         self.current_run_states()

--- a/m87-server/src/models/api_key.rs
+++ b/m87-server/src/models/api_key.rs
@@ -103,7 +103,15 @@ impl ApiKeyDoc {
             .map_err(|_| ServerError::internal_error("DB lookup failed"))?
             .ok_or_else(|| ServerError::unauthorized("Invalid key ID"))?;
 
-        if !verify_api_key(&secret, &key_doc.key_hash) {
+        // Argon2 verification is deliberately CPU-heavy (tens of ms). Run it on
+        // the blocking pool so a burst of authenticating devices can't pin the
+        // async worker threads and wedge the whole server.
+        let secret_owned = secret.to_string();
+        let hash_owned = key_doc.key_hash.clone();
+        let valid = tokio::task::spawn_blocking(move || verify_api_key(&secret_owned, &hash_owned))
+            .await
+            .map_err(|_| ServerError::internal_error("API key verification task failed"))?;
+        if !valid {
             return Err(ServerError::unauthorized("Invalid API key"));
         }
 
@@ -162,4 +170,21 @@ fn generate_api_key() -> Result<(String, String, String), PasswordHashError> {
 fn split_api_key(key: &str) -> Option<(String, String)> {
     let mut parts = key.splitn(2, '.');
     Some((parts.next()?.to_string(), parts.next()?.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards the Argon2 hash/verify contract, so moving `verify_api_key` onto
+    /// the blocking pool can't silently break API-key auth.
+    #[test]
+    fn api_key_hash_roundtrips() {
+        let hash = hash_api_key("s3cret-key").expect("hash should succeed");
+        assert!(verify_api_key("s3cret-key", &hash), "correct key must verify");
+        assert!(
+            !verify_api_key("wrong-key", &hash),
+            "wrong key must not verify"
+        );
+    }
 }

--- a/m87-server/src/models/deploy_spec.rs
+++ b/m87-server/src/models/deploy_spec.rs
@@ -775,9 +775,14 @@ impl DeployReportDoc {
         }
 
         // 2) Query Mongo with a cursor; stream docs and update snapshot in place.
-        // Sort by report_time ascending so “latest” comparisons are cheap and predictable.
+        // Sort by `created_at` (receive time) ascending so the in-place fold
+        // applies reports in chronological order and "latest wins". NOTE: the
+        // old sort key `report_time` is not a top-level field on the report doc
+        // (it lives under `kind.data.report_time`), so it sorted on a missing
+        // field — an unindexable, blocking in-memory sort. `created_at` is a
+        // real field backed by the {device_id, revision_id, created_at} index.
         let options = FindOptions::builder()
-            .sort(doc! { "report_time": 1i32 })
+            .sort(doc! { "created_at": 1i32 })
             .batch_size(Some(256))
             .build();
 

--- a/m87-server/src/models/deploy_spec.rs
+++ b/m87-server/src/models/deploy_spec.rs
@@ -16,7 +16,7 @@ use m87_shared::{
 use mongodb::{
     bson::{Bson, DateTime as BsonDateTime, Document, doc, oid::ObjectId, to_bson},
     error::{ErrorKind, WriteFailure},
-    options::{FindOptions, UpdateOptions},
+    options::{FindOptions, UpdateModifications, UpdateOptions},
 };
 use serde::{Deserialize, Serialize};
 
@@ -61,9 +61,33 @@ impl AccessControlled for DeployRevisionDoc {
     }
 }
 
+/// Build an aggregation-pipeline update that removes any existing element of
+/// `field` (a `revision.<units>` array) whose `id` matches, then appends the new
+/// unit. Using a pipeline lets us express "supersede-by-id" atomically — a plain
+/// `$push` blindly appends and leaves the previous version of the unit behind,
+/// which is why re-deploying a unit used to leave the old container/process
+/// running on the device (it was never seen as removed from the revision).
+fn supersede_unit_by_id(field: &str, id: &str, unit: Bson) -> UpdateModifications {
+    let field_ref = format!("${field}");
+    let concat = doc! {
+        "$concatArrays": [
+            {
+                "$filter": {
+                    "input": { "$ifNull": [field_ref, []] },
+                    "cond": { "$ne": ["$$this.id", id] },
+                }
+            },
+            [unit],
+        ]
+    };
+    let mut set = Document::new();
+    set.insert(field, concat);
+    UpdateModifications::Pipeline(vec![doc! { "$set": set }])
+}
+
 pub fn to_update_doc(
     body: &UpdateDeployRevisionBody,
-) -> ServerResult<(Document, Option<Document>)> {
+) -> ServerResult<(UpdateModifications, Option<Document>)> {
     let mut which = 0;
     if body.revision.is_some() {
         which += 1;
@@ -111,7 +135,7 @@ pub fn to_update_doc(
         let rev: DeploymentRevision = DeploymentRevision::from_yaml(yaml)
             .map_err(|e| ServerError::bad_request(&format!("invalid YAML in `revision`: {}", e)))?;
         return Ok((
-            doc! { "$set": { "revision": to_bson(&rev).map_err(|e| ServerError::bad_request(&format!("revision -> bson failed: {}", e)))? } },
+            doc! { "$set": { "revision": to_bson(&rev).map_err(|e| ServerError::bad_request(&format!("revision -> bson failed: {}", e)))? } }.into(),
             None,
         ));
     }
@@ -120,8 +144,10 @@ pub fn to_update_doc(
         let spec: ServiceSpec = ServiceSpec::from_yaml(yaml).map_err(|e| {
             ServerError::bad_request(&format!("invalid YAML in `add_service`: {}", e))
         })?;
+        let bson = to_bson(&spec)
+            .map_err(|e| ServerError::bad_request(&format!("ServiceSpec -> bson failed: {}", e)))?;
         return Ok((
-            doc! { "$push": { "revision.services": to_bson(&spec).map_err(|e| ServerError::bad_request(&format!("ServiceSpec -> bson failed: {}", e)))? } },
+            supersede_unit_by_id("revision.services", &spec.id, bson),
             None,
         ));
     }
@@ -130,8 +156,10 @@ pub fn to_update_doc(
         let spec: ServiceSpec = ServiceSpec::from_yaml(yaml).map_err(|e| {
             ServerError::bad_request(&format!("invalid YAML in `add_observer`: {}", e))
         })?;
+        let bson = to_bson(&spec)
+            .map_err(|e| ServerError::bad_request(&format!("ServiceSpec -> bson failed: {}", e)))?;
         return Ok((
-            doc! { "$push": { "revision.observers": to_bson(&spec).map_err(|e| ServerError::bad_request(&format!("ServiceSpec -> bson failed: {}", e)))? } },
+            supersede_unit_by_id("revision.observers", &spec.id, bson),
             None,
         ));
     }
@@ -139,10 +167,9 @@ pub fn to_update_doc(
     if let Some(yaml) = &body.add_job {
         let job: JobDef = JobDef::from_yaml(yaml)
             .map_err(|e| ServerError::bad_request(&format!("invalid YAML in `add_job`: {}", e)))?;
-        return Ok((
-            doc! { "$push": { "revision.jobs": to_bson(&job).map_err(|e| ServerError::bad_request(&format!("JobDef -> bson failed: {}", e)))? } },
-            None,
-        ));
+        let bson = to_bson(&job)
+            .map_err(|e| ServerError::bad_request(&format!("JobDef -> bson failed: {}", e)))?;
+        return Ok((supersede_unit_by_id("revision.jobs", &job.id, bson), None));
     }
 
     if let Some(id) = &body.remove_unit_id {
@@ -154,7 +181,8 @@ pub fn to_update_doc(
                     "revision.observers": { "id": id },
                     "revision.jobs": { "id": id },
                 }
-            },
+            }
+            .into(),
             None,
         ));
     }
@@ -163,11 +191,11 @@ pub fn to_update_doc(
         // Lifecycle updates are delivered to the device via heartbeat.
         // No revision document change is needed here; return a no-op set.
         // TODO: persist lifecycle_update to a pending queue for heartbeat delivery.
-        return Ok((doc! { "$set": { "dirty": true } }, None));
+        return Ok((doc! { "$set": { "dirty": true } }.into(), None));
     }
 
     if let Some(active) = body.active {
-        return Ok((doc! { "$set": { "active": active } }, None));
+        return Ok((doc! { "$set": { "active": active } }.into(), None));
     }
 
     // Legacy backward-compat fields
@@ -190,8 +218,10 @@ pub fn to_update_doc(
                         e
                     ))
                 })?;
+                let bson =
+                    to_bson(&spec).map_err(|e| ServerError::bad_request(&e.to_string()))?;
                 return Ok((
-                    doc! { "$push": { "revision.observers": to_bson(&spec).map_err(|e| ServerError::bad_request(&e.to_string()))? } },
+                    supersede_unit_by_id("revision.observers", &spec.id, bson),
                     None,
                 ));
             }
@@ -202,10 +232,9 @@ pub fn to_update_doc(
                         e
                     ))
                 })?;
-                return Ok((
-                    doc! { "$push": { "revision.jobs": to_bson(&jd).map_err(|e| ServerError::bad_request(&e.to_string()))? } },
-                    None,
-                ));
+                let bson =
+                    to_bson(&jd).map_err(|e| ServerError::bad_request(&e.to_string()))?;
+                return Ok((supersede_unit_by_id("revision.jobs", &jd.id, bson), None));
             }
             _ => {
                 // Default: service
@@ -215,8 +244,10 @@ pub fn to_update_doc(
                         e
                     ))
                 })?;
+                let bson =
+                    to_bson(&spec).map_err(|e| ServerError::bad_request(&e.to_string()))?;
                 return Ok((
-                    doc! { "$push": { "revision.services": to_bson(&spec).map_err(|e| ServerError::bad_request(&e.to_string()))? } },
+                    supersede_unit_by_id("revision.services", &spec.id, bson),
                     None,
                 ));
             }
@@ -231,7 +262,10 @@ pub fn to_update_doc(
 
     if let Some(id) = &body.remove_run_spec_id {
         // Legacy: remove from jobs only (backward compat)
-        return Ok((doc! { "$pull": { "revision.jobs": { "id": id } } }, None));
+        return Ok((
+            doc! { "$pull": { "revision.jobs": { "id": id } } }.into(),
+            None,
+        ));
     }
 
     Err(ServerError::internal_error("This should be unreachable"))
@@ -1426,5 +1460,67 @@ impl JobRunDoc {
             .find_one(doc! { "device_id": device_id, "run_id": run_id })
             .await?;
         Ok(doc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reproduces Bug 1: the default `deploy` (add_service / add_observer /
+    // add_job) blindly appends a new unit via Mongo `$push`. Re-deploying a unit
+    // whose `id` already exists in the revision therefore leaves the OLD entry in
+    // place next to the new one. On the device the old unit is never classified
+    // as "removed" from the desired revision, so its stop steps never run — the
+    // previous container/process keeps running alongside the new version.
+    //
+    // A correct update must supersede the existing unit by id (filter out the
+    // same id, then append). A plain `$push` cannot express that — it is purely
+    // additive — so its presence here is the bug.
+    // Asserts the produced update supersedes-by-id: an aggregation pipeline that
+    // `$filter`s out the existing id before appending, rather than a blind
+    // `$push` that would duplicate the unit on re-deploy.
+    fn assert_supersedes_by_id(update: &UpdateModifications, ctx: &str) {
+        let rendered = format!("{update:?}");
+        assert!(
+            !rendered.contains("$push"),
+            "{ctx} must replace-or-append by id, not blindly `$push` a duplicate \
+             (re-deploying the same id must not leave the old unit in the \
+             revision). got: {rendered}"
+        );
+        assert!(
+            rendered.contains("$filter"),
+            "{ctx} must filter out the existing id before appending. got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn add_service_supersedes_existing_id_instead_of_appending() {
+        let body = UpdateDeployRevisionBody {
+            add_service: Some("id: app\n".to_string()),
+            ..Default::default()
+        };
+        let (update, _extra) = to_update_doc(&body).expect("to_update_doc");
+        assert_supersedes_by_id(&update, "add_service");
+    }
+
+    #[test]
+    fn add_observer_supersedes_existing_id_instead_of_appending() {
+        let body = UpdateDeployRevisionBody {
+            add_observer: Some("id: obs\n".to_string()),
+            ..Default::default()
+        };
+        let (update, _extra) = to_update_doc(&body).expect("to_update_doc");
+        assert_supersedes_by_id(&update, "add_observer");
+    }
+
+    #[test]
+    fn add_job_supersedes_existing_id_instead_of_appending() {
+        let body = UpdateDeployRevisionBody {
+            add_job: Some("id: job\n".to_string()),
+            ..Default::default()
+        };
+        let (update, _extra) = to_update_doc(&body).expect("to_update_doc");
+        assert_supersedes_by_id(&update, "add_job");
     }
 }

--- a/m87-server/src/relay/relay_state.rs
+++ b/m87-server/src/relay/relay_state.rs
@@ -65,24 +65,80 @@ impl RelayState {
     }
 
     /// Returns true only if device has an active and *not lost* tunnel.
+    ///
+    /// Locks are acquired `tunnels` before `lost`, matching `remove_if_match`
+    /// and `replace_tunnel`. A consistent order across all methods is what
+    /// prevents the AB-BA deadlock between the two relay locks.
     pub async fn has_tunnel(&self, device_short_id: &str) -> bool {
-        let lost = self.lost.read().await;
-        if lost.contains_key(device_short_id) {
+        let tunnels = self.tunnels.read().await;
+        if !tunnels.contains_key(device_short_id) {
             return false;
         }
 
-        let tunnels = self.tunnels.read().await;
-        tunnels.contains_key(device_short_id)
+        let lost = self.lost.read().await;
+        !lost.contains_key(device_short_id)
     }
 
-    /// Return active (non-lost) tunnel
+    /// Return active (non-lost) tunnel.
+    ///
+    /// Locks are acquired `tunnels` before `lost` (see `has_tunnel`).
     pub async fn get_tunnel(&self, device_short_id: &str) -> Option<Connection> {
+        let tunnels = self.tunnels.read().await;
+        let conn = tunnels.get(device_short_id).cloned()?;
+
         let lost = self.lost.read().await;
         if lost.contains_key(device_short_id) {
             return None;
         }
+        Some(conn)
+    }
+}
 
-        let tunnels = self.tunnels.read().await;
-        tunnels.get(device_short_id).cloned()
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    /// Reproduces the AB-BA deadlock between `tunnels` and `lost`.
+    ///
+    /// `remove_if_match` acquires `tunnels.write()` then `lost.write()`
+    /// (tunnels -> lost), while `has_tunnel`/`get_tunnel` acquire
+    /// `lost.read()` then `tunnels.read()` (lost -> tunnels). With a reader
+    /// in flight, a writer holding `tunnels` can never obtain `lost` and the
+    /// whole relay wedges.
+    ///
+    /// We simulate the writer side by holding `tunnels.write()` (exactly what
+    /// `remove_if_match` holds when it reaches `lost.write()`), run the *real*
+    /// `has_tunnel` concurrently, then assert the writer can still acquire
+    /// `lost.write()`. On the pre-fix reader ordering this times out.
+    #[tokio::test]
+    async fn writer_is_not_deadlocked_by_concurrent_reader() {
+        let state = RelayState::new();
+
+        // Writer side: hold `tunnels.write()`, as `remove_if_match` does.
+        let tunnels_guard = state.tunnels.write().await;
+
+        // Reader side: real `has_tunnel`, running concurrently.
+        let reader_state = state.clone();
+        let reader = tokio::spawn(async move { reader_state.has_tunnel("device-1").await });
+
+        // Let the reader reach its first lock acquisition and park on the
+        // second one. On current-thread runtime this yields to `reader`.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Now complete the writer's second acquisition. With a consistent
+        // `tunnels -> lost` order this succeeds immediately; with the buggy
+        // `lost -> tunnels` reader order the reader holds `lost.read()` while
+        // blocked on `tunnels.read()`, so this blocks forever.
+        let acquired = timeout(Duration::from_secs(3), state.lost.write()).await;
+        assert!(
+            acquired.is_ok(),
+            "writer holding `tunnels` could not acquire `lost` while a reader \
+             was in flight — AB-BA deadlock between the relay locks"
+        );
+
+        drop(tunnels_guard);
+        let _ = reader.await;
     }
 }

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +162,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bollard"
 version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +209,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -226,6 +260,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bitvec",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
+ "hex",
+ "indexmap 2.12.1",
+ "js-sys",
+ "once_cell",
+ "rand 0.9.2",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +317,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +337,55 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -286,6 +403,70 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -323,6 +504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +517,62 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -405,7 +648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0e9414a6ae93ef993ce40a1e02944f13d4508e2bf6f1ced1580ce6910f08253"
 dependencies = [
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "web-time",
 ]
 
@@ -441,6 +684,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -532,6 +781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,9 +812,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -594,6 +865,85 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.2",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -912,10 +1262,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -941,6 +1307,55 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -988,6 +1403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1422,54 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "matchers"
@@ -1013,6 +1485,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1036,6 +1518,105 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "mongocrypt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da0cd419a51a5fb44819e290fbdb0665a54f21dead8923446a799c7f4d26ad9"
+dependencies = [
+ "bson",
+ "mongocrypt-sys",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "mongocrypt-sys"
+version = "0.1.6+1.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851fac73f7fe22f6a3ab87f720ce509cae7c9fd08e7dd27866cc232dee07ccf4"
+
+[[package]]
+name = "mongodb"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags",
+ "bson",
+ "derive-where",
+ "derive_more",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hickory-net",
+ "hickory-proto",
+ "hickory-resolver",
+ "hmac",
+ "macro_magic",
+ "md-5",
+ "mongocrypt",
+ "mongodb-internal-macros",
+ "pbkdf2",
+ "percent-encoding",
+ "rand 0.9.2",
+ "rustc_version_runtime",
+ "rustls",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha1",
+ "sha2",
+ "socket2",
+ "stringprep",
+ "strsim",
+ "take_mut",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "typed-builder",
+ "uuid",
+ "webpki-roots",
+]
+
+[[package]]
+name = "mongodb-internal-macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ceb1a9a1018e470077ec94cf3a8c2d0e6da542b2c05ea95a59a0a627147375"
+dependencies = [
+ "macro_magic",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1130,12 +1711,39 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "parse-display"
@@ -1160,6 +1768,15 @@ dependencies = [
  "regex-syntax",
  "structmeta",
  "syn",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1228,6 +1845,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -1300,7 +1928,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1342,13 +1970,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1358,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1369,6 +2020,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1467,6 +2124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +2148,25 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1569,6 +2251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,13 +2293,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1625,6 +2322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +2335,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1660,6 +2373,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap 2.12.1",
  "itoa",
  "memchr",
  "ryu",
@@ -1722,6 +2436,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +2480,22 @@ checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1772,6 +2524,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -1840,6 +2603,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +2688,7 @@ dependencies = [
 name = "tests"
 version = "0.0.0-dev0"
 dependencies = [
+ "mongodb",
  "regex",
  "reqwest",
  "serde_json",
@@ -1956,6 +2759,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2039,7 +2851,9 @@ checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2201,10 +3015,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2272,6 +3145,7 @@ checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2280,6 +3154,22 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2393,6 +3283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,6 +3303,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2454,6 +3359,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -2640,6 +3556,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xattr"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2021"
 
 [features]
 default = []
-e2e = []
+e2e = ["dep:mongodb"]
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "time", "sync"] }
 testcontainers = "0.26.0"
+mongodb = { version = "3", optional = true }
 reqwest = { version = "0.12.25", default-features = false, features = ["rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
 regex = "1"

--- a/tests/src/e2e_containers/mod.rs
+++ b/tests/src/e2e_containers/mod.rs
@@ -14,6 +14,7 @@ pub mod helpers;
 mod install;
 mod ls;
 mod misc;
+mod mongo_indexes;
 mod monitoring;
 pub mod setup;
 mod forward;

--- a/tests/src/e2e_containers/mongo_indexes.rs
+++ b/tests/src/e2e_containers/mongo_indexes.rs
@@ -1,0 +1,78 @@
+//! E2E: the m87-server must create its MongoDB indexes at startup.
+//!
+//! `Mongo::ensure_indexes` runs on server boot. Missing/mis-shaped indexes on
+//! the heartbeat-report hot path turn the deployment-status snapshot query into
+//! a full collection scan + blocking in-memory sort in `mongod`, which drives
+//! CPU and memory up under the report flood. This test brings up the real stack
+//! (the server runs `ensure_indexes`), then connects to the Mongo container
+//! directly and asserts the hot-path indexes exist.
+
+use super::containers::E2EInfra;
+use super::helpers::E2EError;
+use mongodb::bson::Document;
+use mongodb::Client;
+
+/// Index names for a collection. MongoDB auto-names an index by joining
+/// `<field>_<direction>` with `_`, so these names are deterministic.
+async fn index_names(client: &Client, db: &str, collection: &str) -> Result<Vec<String>, E2EError> {
+    client
+        .database(db)
+        .collection::<Document>(collection)
+        .list_index_names()
+        .await
+        .map_err(|e| E2EError::Setup(format!("list_index_names({collection}): {e}")))
+}
+
+#[tokio::test]
+async fn server_creates_expected_indexes() -> Result<(), E2EError> {
+    let infra = E2EInfra::init().await?;
+
+    // The server ran `ensure_indexes` against DB "e2e-tests" (see
+    // containers.rs: MONGO_DB) at boot. Connect to the same Mongo container
+    // directly via its mapped host port.
+    let port = infra
+        .mongo
+        .get_host_port_ipv4(27017)
+        .await
+        .map_err(|e| E2EError::Setup(e.to_string()))?;
+    let client = Client::with_uri_str(format!("mongodb://localhost:{port}"))
+        .await
+        .map_err(|e| E2EError::Setup(e.to_string()))?;
+    let db = "e2e-tests";
+
+    // deploy_reports: the NON-partial {device_id, revision_id, created_at, _id}
+    // index the snapshot / RunState-list reads rely on. If this is missing (or
+    // reverts to being partial on `kind.type`), the unfiltered snapshot query
+    // can't use it and falls back to a scan + in-memory sort.
+    let deploy_reports = index_names(&client, db, "deploy_reports").await?;
+    assert!(
+        deploy_reports
+            .iter()
+            .any(|n| n == "device_id_1_revision_id_1_created_at_-1__id_-1"),
+        "deploy_reports is missing the non-partial created_at index; have: {deploy_reports:?}"
+    );
+
+    // deploy_revisions: `get_by_revision_id` filters `revision.id` alone.
+    let deploy_revisions = index_names(&client, db, "deploy_revisions").await?;
+    assert!(
+        deploy_revisions.iter().any(|n| n == "revision.id_1"),
+        "deploy_revisions is missing the revision.id index; have: {deploy_revisions:?}"
+    );
+
+    // audit_logs: `list_for_device` filters device_id, sorts timestamp desc.
+    let audit_logs = index_names(&client, db, "audit_logs").await?;
+    assert!(
+        audit_logs.iter().any(|n| n == "device_id_1_timestamp_-1"),
+        "audit_logs is missing the {{device_id, timestamp}} index; have: {audit_logs:?}"
+    );
+
+    // users: lookups by email (`{email}` and `{email: {$in}}`).
+    let users = index_names(&client, db, "users").await?;
+    assert!(
+        users.iter().any(|n| n == "email_1"),
+        "users is missing the email index; have: {users:?}"
+    );
+
+    tracing::info!("All expected MongoDB indexes are present");
+    Ok(())
+}


### PR DESCRIPTION
# Summary

Reliability and performance fixes across the m87 client and server, uncovered while chasing heartbeat spam, missing live logs, intermittent server hangs, and a deploy that left stale containers running.

## Client
- **Heartbeat spam / CPU starvation:** unhealthy observe reports were level-triggered, re-emitting a unique report every `fails_after` cycle forever. This flooded the on-disk event queue and pinned a core. Now edge-triggered — one report per healthy↔unhealthy transition.
- **Missing live logs:** observe/service follow logs rode the tracing broadcast *behind* the global `EnvFilter`, so running the daemon below INFO silently dropped them. The broadcast layer now has its own filter and always admits `observe` output regardless of `RUST_LOG`.
- **Deploy teardown failures swallowed:** when reconcile ran a unit's stop steps, a failure was discarded via `let _ = stop_service(...)` — the unit was left half-torn-down, the dirty flag was cleared, and reconcile reported success with no error and no retry. The failure is now surfaced (reconcile errors) and the unit stays dirty so the stop is retried.

## Server
- **Relay deadlock (the "restart fixes it" bug):** `has_tunnel`/`get_tunnel` locked `lost`→`tunnels`, the opposite order to `remove_if_match`, causing an AB-BA deadlock under concurrent connect/disconnect + device-list reads. Unified on `tunnels`→`lost`.
- **Old unit never stopped on update:** `deploy` (`add_service`/`add_observer`/`add_job`, plus the legacy `add_run_spec` routes) `$push`-appended the unit onto the revision array, so re-deploying an existing id left the old entry in place. On the device the old unit was never classified as removed from the desired revision, so its stop steps never ran — the previous container/process kept running alongside the new version (customers worked around this with `--replace-all`). These now **supersede by id** via an aggregation-pipeline update that filters out any element with the same id before appending; `to_update_doc` returns `UpdateModifications` to emit the pipeline.
- **Query/index fixes:** deployment-status snapshot sorted on a non-existent field (`report_time`) → blocking in-memory sort over full history; now sorts on indexed `created_at`. Made the `deploy_reports` index non-partial and added indexes for `deploy_revisions.revision.id`, `audit_logs`, `users.email`.
- **Hardening:** Argon2 API-key verify → `spawn_blocking`; shared reqwest client with timeout for JWKS/userinfo; Mongo `max_pool_size` raised to 50.

## Tests
Regression tests for each fix (heartbeat edge-trigger, log-level decoupling, relay deadlock, Argon2 round-trip) + an e2e testcontainers test asserting the server creates its indexes at startup. All reproduced red before fixing where applicable.

New for the deploy fixes:
- **Server:** first unit tests for `to_update_doc`, asserting `add_service`/`add_observer`/`add_job` supersede-by-id rather than blindly `$push` (each red before the fix, showing the `$push` in the panic output).
- **Client:** `failed_stop_step_is_not_silently_swallowed` — reconcile surfaces a failing stop step instead of discarding it.
- Validated against the `deployment` + `backward_compat` e2e testcontainers files (7/7 green, incl. the same-id re-apply upgrade-safety case).