### PR TITLE
Fix/0.8.2 cleanup and size

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,19 @@ jobs:
           mkdir -p release-assets
           # This will copy binaries, install script (later), AND both THIRDPARTY_LICENSES.html files
           find artifacts -type f -exec cp {} release-assets/ \;
+
+          # Additionally publish a gzip-compressed copy of each CLIENT binary
+          # (~2.5x smaller — matters for LTE edge devices). This is ADDITIVE: the
+          # raw `m87-<target>` asset stays so older self-updaters (and 0.7.x)
+          # keep working, while the 0.8.2+ client prefers the `.gz`. Server
+          # binaries are not self-updated over the wire, so they are skipped.
+          for f in release-assets/m87-*; do
+            case "$f" in
+              *m87-server-*|*.gz|*.html|*SHA256SUMS*) continue ;;
+            esac
+            gzip -9 -k "$f"   # -k keeps the raw file alongside the .gz
+            echo "compressed $f -> $f.gz"
+          done
           ls -lh release-assets/
 
       - name: Add install script to release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,6 +2742,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "filetime",
+ "flate2",
  "futures",
  "homedir",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,14 +63,19 @@ quinn = "0.11"
 quinn-proto = "0.11"
 
 [profile.release]
-# Optimize for SIZE — the client ships to LTE-connected edge devices where the
-# self-update download time dominates, and the workload is I/O-bound (async
-# supervisor / relay), so trading a little codegen speed for a smaller binary is
-# the right call for both the device and the server.
-opt-level = "z"            # Optimize for size (was 3); biggest lever for the LTE download
+# Server + default: optimize for performance.
+opt-level = 3              # Maximum optimization
 lto = "fat"                # Full link-time optimization for better dead code elimination
 codegen-units = 1          # Better optimization at the cost of compile time
 strip = true               # Strip debug symbols from binary
-# NOTE: kept panic = "unwind" (default) on purpose — panic = "abort" would shave
-# a bit more but makes a panic in any spawned task abort the whole process, which
-# is unsafe for the server's per-request task isolation.
+
+# Client-only size profile. The device binary ships to LTE-connected edge
+# devices where the self-update download time dominates, so we trade a little
+# codegen speed for a much smaller binary (opt-level "z"). Built via
+# `--profile release-small` (see m87-client/Dockerfile). The server keeps the
+# perf-tuned [profile.release] above. Kept panic = "unwind" (default) on purpose
+# — panic = "abort" would shave a bit more but makes a panic in any spawned task
+# abort the whole process.
+[profile.release-small]
+inherits = "release"
+opt-level = "z"            # ~20 MB -> ~12.8 MB vs opt-level 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,14 @@ quinn = "0.11"
 quinn-proto = "0.11"
 
 [profile.release]
-# Optimize for performance and minimal resource footprint
-# While maintaining safety for long-running edge devices
-opt-level = 3              # Maximum optimization
+# Optimize for SIZE — the client ships to LTE-connected edge devices where the
+# self-update download time dominates, and the workload is I/O-bound (async
+# supervisor / relay), so trading a little codegen speed for a smaller binary is
+# the right call for both the device and the server.
+opt-level = "z"            # Optimize for size (was 3); biggest lever for the LTE download
 lto = "fat"                # Full link-time optimization for better dead code elimination
 codegen-units = 1          # Better optimization at the cost of compile time
 strip = true               # Strip debug symbols from binary
+# NOTE: kept panic = "unwind" (default) on purpose — panic = "abort" would shave
+# a bit more but makes a panic in any spawned task abort the whole process, which
+# is unsafe for the server's per-request task isolation.

--- a/m87-client/Cargo.toml
+++ b/m87-client/Cargo.toml
@@ -91,3 +91,8 @@ chrono = "0.4"
 
 # MCP (Model Context Protocol) server
 rmcp = { version = "0.16.0", features = ["server", "macros", "transport-io"] }
+
+[dev-dependencies]
+# Test-only: build a .gz fixture to verify the self-update gzip-extract path.
+# (flate2 is already in the tree via self_update's compression-flate2 feature.)
+flate2 = "1"

--- a/m87-client/Dockerfile
+++ b/m87-client/Dockerfile
@@ -43,12 +43,14 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
       export TARGET="x86_64-unknown-linux-musl"; \
     fi && \
     if [ "$BUILD_PROFILE" = "release" ]; then \
-      cargo build --release --target $TARGET --package m87-client --features runtime,cli; \
+      cargo build --profile release-small --target $TARGET --package m87-client --features runtime,cli; \
+      OUT_DIR="release-small"; \
     else \
       cargo build --target $TARGET --package m87-client --features runtime,cli; \
+      OUT_DIR="debug"; \
     fi && \
     mkdir -p /workspace/out && \
-    cp /workspace/target/$TARGET/${BUILD_PROFILE}/m87 /workspace/out/m87
+    cp /workspace/target/$TARGET/$OUT_DIR/m87 /workspace/out/m87
 
 # ===========================
 # Runtime Stage (for e2e tests and container deployments)

--- a/m87-client/install.sh
+++ b/m87-client/install.sh
@@ -255,30 +255,44 @@ main() {
     tmp_dir=$(mktemp -d)
     trap 'rm -rf "$tmp_dir"' EXIT
 
-    # Step 3: Download binary
+    # Step 3+4: Download binary (preferring the smaller gzip asset) + verify.
     binary_name="${BINARY_NAME}-${TARGET}"
-    download_url="${DOWNLOAD_BASE_URL}/v${VERSION}/${binary_name}"
     binary_path="$tmp_dir/$binary_name"
+    gz_name="${binary_name}.gz"
 
-    info "Downloading $binary_name..."
-    download "$download_url" "$binary_path"
-    success "Downloaded binary"
-
-    # Step 4: Download and verify checksum
-    info "Verifying checksum..."
+    # Fetch the checksum list up front so we can verify whichever asset we pull.
     checksums_url="${DOWNLOAD_BASE_URL}/v${VERSION}/SHA256SUMS"
     checksums_file="$tmp_dir/SHA256SUMS"
+    download "$checksums_url" "$checksums_file" 2>/dev/null || true
 
-    if download "$checksums_url" "$checksums_file" 2>/dev/null; then
-        expected_checksum=$(grep "$binary_name" "$checksums_file" | awk '{print $1}')
-
-        if [ -n "$expected_checksum" ]; then
-            verify_checksum "$binary_path" "$expected_checksum"
-        else
-            warning "Checksum not found in SHA256SUMS, skipping verification"
+    # Exact-match a filename in SHA256SUMS (both `m87-<t>` and `m87-<t>.gz` are
+    # listed, so a substring match would be ambiguous) and verify.
+    verify_named() {
+        _file="$1"; _name="$2"
+        if [ ! -s "$checksums_file" ]; then
+            warning "Could not download SHA256SUMS, skipping verification"
+            return
         fi
+        _sum=$(awk -v n="$_name" '$2 == n {print $1}' "$checksums_file" | head -n1)
+        if [ -n "$_sum" ]; then
+            verify_checksum "$_file" "$_sum"
+        else
+            warning "Checksum for $_name not found in SHA256SUMS, skipping verification"
+        fi
+    }
+
+    if command -v gunzip >/dev/null 2>&1 && \
+       download "${DOWNLOAD_BASE_URL}/v${VERSION}/${gz_name}" "$tmp_dir/$gz_name" 2>/dev/null; then
+        info "Downloaded $gz_name (compressed)"
+        verify_named "$tmp_dir/$gz_name" "$gz_name"   # verify the .gz, then decompress
+        gunzip -c "$tmp_dir/$gz_name" > "$binary_path"
+        success "Downloaded and decompressed binary"
     else
-        warning "Could not download SHA256SUMS, skipping verification"
+        # Fall back to the raw binary (older releases, or no gunzip available).
+        info "Downloading $binary_name..."
+        download "${DOWNLOAD_BASE_URL}/v${VERSION}/${binary_name}" "$binary_path"
+        verify_named "$binary_path" "$binary_name"
+        success "Downloaded binary"
     fi
 
     # Step 5: Remove macOS quarantine attribute (if on macOS)

--- a/m87-client/src/device/deployment_manager.rs
+++ b/m87-client/src/device/deployment_manager.rs
@@ -612,11 +612,74 @@ impl DeploymentManager {
     // start – the main supervisor loop
     // -----------------------------------------------------------------------
 
+    /// One-time cleanup of pre-0.8 (0.7.x) deployment workspaces.
+    ///
+    /// 0.7.x ran compose services under `<root>/jobs/<id>` (persistent) and
+    /// `<root>/tmp/jobs/<hash>` (ephemeral), so a unit's docker-compose project
+    /// name was that directory's basename. 0.8.x instead uses
+    /// `<root>/workspaces/<id>`, so after an upgrade the containers 0.7.x started
+    /// are orphaned under project names the new client never references: they
+    /// keep running (and docker's restart policy resurrects them on reboot),
+    /// fighting the 0.8.x containers for resources.
+    ///
+    /// These two directories are NEVER created by 0.8.x, so reaping them is
+    /// safe: for each leftover workspace we run `docker compose down` from inside
+    /// it (using the compose file 0.7.x materialized there, hence the same
+    /// project name it created the containers with), then remove the directory.
+    /// Best-effort throughout — a device with no leftovers is a no-op, and after
+    /// the first successful pass the directories are gone so it stays a no-op.
+    pub(crate) async fn reap_legacy_workspaces(&self) {
+        for sub in ["jobs", "tmp/jobs"] {
+            let base = self.root_dir.join(sub);
+            let mut rd = match tokio::fs::read_dir(&base).await {
+                Ok(rd) => rd,
+                Err(_) => continue, // directory absent → nothing to reap
+            };
+            while let Ok(Some(entry)) = rd.next_entry().await {
+                let path = entry.path();
+                let is_dir = entry
+                    .file_type()
+                    .await
+                    .map(|t| t.is_dir())
+                    .unwrap_or(false);
+                if !is_dir {
+                    continue;
+                }
+                tracing::warn!(
+                    "reaping pre-0.8 deployment workspace {} (orphaned by the 0.7.x→0.8.x upgrade)",
+                    path.display()
+                );
+                // Tear the old compose project down. Running `down` from the
+                // leftover workspace picks up its materialized compose file and
+                // the same (basename-derived) project name 0.7.x used, so this
+                // targets exactly those containers. Best-effort: no compose file,
+                // no docker, or an already-gone project all no-op.
+                let cmd = format!(
+                    "cd '{}' && docker compose down --remove-orphans",
+                    path.display()
+                );
+                let _ = tokio::process::Command::new("/bin/sh")
+                    .arg("-lc")
+                    .arg(&cmd)
+                    .output()
+                    .await;
+                let _ = tokio::fs::remove_dir_all(&path).await;
+            }
+            // Remove the now-empty legacy parent dir so the reap is a clean no-op next boot.
+            let _ = tokio::fs::remove_dir(&base).await;
+        }
+    }
+
     pub fn start(self: Arc<Self>) {
         tokio::spawn(async move {
             let mut next_health: HashMap<String, Instant> = HashMap::new();
             let mut next_liveness: HashMap<String, Instant> = HashMap::new();
             let tick = Duration::from_millis(250);
+
+            // Reap 0.7.x-era orphaned compose projects before reconciling, so an
+            // upgraded device doesn't run duplicate containers fighting for
+            // resources. Safe/no-op on a device that was always on 0.8.x.
+            self.reap_legacy_workspaces().await;
 
             let _ = self.set_dirty_services().await;
 
@@ -1859,6 +1922,43 @@ mod tests {
     // (reconcile_dirty), so a FAILING stop step is silently discarded: reconcile
     // returns Ok and clears the dirty flag, leaving a half-torn-down unit with no
     // error surfaced and no retry. A failing stop must not be swallowed.
+    // Reaps 0.7.x-era leftover workspaces (which orphaned containers on upgrade)
+    // while leaving 0.8.x's own `workspaces/` untouched.
+    #[tokio::test]
+    async fn reaps_legacy_workspaces_but_not_new_ones() -> Result<()> {
+        let td = TempDir::new()?;
+        let mgr = make_mgr(&td).await;
+        let root = mgr.root_dir.clone();
+
+        // 0.7.x leftovers: persistent `jobs/<id>` and ephemeral `tmp/jobs/<hash>`.
+        std::fs::create_dir_all(root.join("jobs/old-svc"))?;
+        std::fs::write(
+            root.join("jobs/old-svc/docker-compose.yml"),
+            "services: {}\n",
+        )?;
+        std::fs::create_dir_all(root.join("tmp/jobs/deadbeefcafef00d"))?;
+
+        // 0.8.x's own workspace — must survive the reap.
+        std::fs::create_dir_all(root.join("workspaces/live-svc"))?;
+        std::fs::write(root.join("workspaces/live-svc/marker"), "keep")?;
+
+        mgr.reap_legacy_workspaces().await;
+
+        assert!(
+            !root.join("jobs").exists(),
+            "legacy jobs/ dir must be reaped"
+        );
+        assert!(
+            !root.join("tmp/jobs").exists(),
+            "legacy tmp/jobs/ dir must be reaped"
+        );
+        assert!(
+            root.join("workspaces/live-svc/marker").exists(),
+            "0.8.x workspace must be left untouched"
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     async fn failed_stop_step_is_not_silently_swallowed() -> Result<()> {
         let td = TempDir::new()?;

--- a/m87-client/src/update/mod.rs
+++ b/m87-client/src/update/mod.rs
@@ -65,41 +65,63 @@ pub async fn update(interactive: bool) -> Result<bool> {
         return Ok(false);
     }
 
-    // Find our asset in the release
-    let asset = release
+    // Prefer the gzip-compressed asset (`<name>.gz`, ~2.5x smaller — matters on
+    // LTE), falling back to the raw binary for releases that only publish it.
+    // This is intentionally additive: releases keep publishing the raw asset so
+    // older clients still work, and this client works against either.
+    let gz_name = format!("{asset_name}.gz");
+    let (asset, is_gz) = release
         .assets
         .iter()
-        .find(|a| a.name == asset_name)
-        .ok_or_else(|| anyhow!("Asset '{}' not found in release", asset_name))?;
+        .find(|a| a.name == gz_name)
+        .map(|a| (a, true))
+        .or_else(|| release.assets.iter().find(|a| a.name == asset_name).map(|a| (a, false)))
+        .ok_or_else(|| {
+            anyhow!("Neither '{}' nor '{}' found in release", gz_name, asset_name)
+        })?;
 
     if interactive {
         println!("New release found: v{} → v{}", current_version, new_version);
-        println!("Downloading {}...", asset_name);
+        println!("Downloading {}...", asset.name);
     }
 
     // Create temp directory for download
     let tmp_dir = self_update::TempDir::new()?;
-    let tmp_path = tmp_dir.path().join(asset_name);
+    let download_path = tmp_dir.path().join(&asset.name);
 
-    // Download the raw binary directly (no archive extraction needed)
-    let tmp_file = File::create(&tmp_path)?;
+    let tmp_file = File::create(&download_path)?;
     self_update::Download::from_url(&asset.browser_download_url)
         .set_header(reqwest::header::ACCEPT, "application/octet-stream".parse()?)
         .show_progress(interactive)
         .download_to(tmp_file)?;
 
+    // If compressed, let self_update gunzip it (ArchiveKind::Plain + Gz — a bare
+    // single-file .gz, not a tar). It writes the decompressed file into the dir
+    // with the `.gz` extension stripped, i.e. `<asset_name>`.
+    let bin_path = if is_gz {
+        if interactive {
+            println!("Decompressing...");
+        }
+        self_update::Extract::from_source(&download_path)
+            .archive(self_update::ArchiveKind::Plain(Some(self_update::Compression::Gz)))
+            .extract_into(tmp_dir.path())?;
+        tmp_dir.path().join(asset_name)
+    } else {
+        download_path
+    };
+
     // Make executable on Unix
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))?;
+        std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755))?;
     }
 
     // Replace the current binary
     if interactive {
         println!("Replacing binary...");
     }
-    self_update::self_replace::self_replace(&tmp_path)?;
+    self_update::self_replace::self_replace(&bin_path)?;
 
     if interactive {
         println!("Updated from v{} → v{}", current_version, new_version);
@@ -173,6 +195,31 @@ mod tests {
         let release: GitHubRelease = serde_json::from_str(json).unwrap();
         assert_eq!(release.tag_name, "v0.0.1");
         assert!(release.assets.is_empty());
+    }
+
+    // Verifies our use of self_update's gzip extraction: a bare `<name>.gz`
+    // extracts to `<name>` (extension stripped) with the original bytes. Guards
+    // the ArchiveKind/output-path assumptions the updater relies on.
+    #[test]
+    fn test_self_update_extracts_plain_gz() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        let dir = self_update::TempDir::new().unwrap();
+        let gz = dir.path().join("m87-x86_64-unknown-linux-musl.gz");
+        let payload = b"\x7fELF not-really-a-binary-but-enough-bytes-to-round-trip";
+
+        let mut enc = GzEncoder::new(File::create(&gz).unwrap(), Compression::best());
+        enc.write_all(payload).unwrap();
+        enc.finish().unwrap();
+
+        self_update::Extract::from_source(&gz)
+            .archive(self_update::ArchiveKind::Plain(Some(self_update::Compression::Gz)))
+            .extract_into(dir.path())
+            .unwrap();
+
+        let out = dir.path().join("m87-x86_64-unknown-linux-musl");
+        assert_eq!(std::fs::read(&out).unwrap(), payload);
     }
 
     #[test]


### PR DESCRIPTION
cleans up the container mess left by the 0.7.x→0.8.x deploy refactor, and makes the client cheap to update over LTE.

## Changes

- **Reap 0.7.x-orphaned compose projects.** The #86 refactor changed the ephemeral compose-project name from `<hash>` (0.7.x: `jobs/`, `tmp/jobs/`) to `<id>` (0.8.x: `workspaces/`). After an upgrade the 0.7.x containers are orphaned under project names the new client never references — they keep running (and docker restarts them on reboot) and fight the 0.8.x containers for resources. On startup the client now `docker compose down`s + removes those two legacy dirs. They're never created by 0.8.x, so it's safe; no-op on always-0.8.x devices. **Upgrading restarts running services once.**

- **Smaller client binary.** Split the release profile: server stays `opt-level=3`, client builds `--profile release-small` (`opt-level="z"`). **20.2 MB → 12.8 MB.**

- **Compressed self-update (additive).** Release now also publishes `m87-<target>.gz` alongside the raw asset (client only). Self-update and `install.sh` prefer the `.gz` (decompressed via `self_update`'s own extractor) and fall back to raw, so 0.7.x / older updaters keep working. **~12.8 MB → ~5.3 MB download.**

## Tests

Unit test for the gz-extract path; `install.sh` gz-preferred + raw-fallback verified against a local mock release; reap test asserts legacy dirs are cleared while `workspaces/` is untouched.

## Notes for release
- Requires the **stable-id** discipline to stop *new* duplicates (version in the image tag, not the `id`) — the reap only cleans existing 0.7.x leftovers.
- Keep publishing the raw asset (0.7.x can't decompress).