### PR TITLE
fix(client): materialize a unit's declared files before its stop steps

### DIFF
--- a/m87-client/src/device/deployment_manager.rs
+++ b/m87-client/src/device/deployment_manager.rs
@@ -1385,6 +1385,19 @@ impl DeploymentManager {
     ) -> Result<()> {
         self.stop_log_follow(&spec.id).await?;
 
+        // Stop steps need the unit's declared `files:` just as startup steps do
+        // — `docker compose down` cannot run without its compose file. With an
+        // ephemeral workdir the directory comes back empty after a runtime
+        // restart, so without this the stop fails permanently. And because a
+        // failed stop keeps the unit dirty with no backoff on the stop path,
+        // reconcile then retries it ~twice a second forever.
+        if let Err(e) = self.materialize_files_svc(spec, wd).await {
+            tracing::warn!(
+                "could not materialize files for '{}' before stop: {e:#}",
+                spec.id
+            );
+        }
+
         if let Some(stop) = &spec.stop {
             self.execute_steps(
                 &spec.id,
@@ -3519,6 +3532,57 @@ mod tests {
                 .join("old_inflight.json")
                 .exists()
         );
+        Ok(())
+    }
+
+    // ── Stop steps must have the unit's declared files ───────────────────────
+    //
+    // `apply_service` materializes a unit's `files:` before running startup
+    // steps, but `stop_service` did not. With `workdir: ephemeral` the workdir
+    // comes back empty after a runtime restart, so a stop step that uses a
+    // declared file (the normal case — `docker compose down` needs its compose
+    // file) fails with "no configuration file provided".
+    //
+    // That failure is not cosmetic: a failed stop keeps the unit dirty and the
+    // stop path has no backoff, so reconcile retried it about twice a second
+    // indefinitely — a self-inflicted denial of service on the device.
+
+    #[tokio::test]
+    async fn stop_steps_get_the_units_declared_files() -> Result<()> {
+        let td = TempDir::new()?;
+        let mgr = make_mgr(&td).await;
+
+        // A stop step that can only succeed if the declared file is present —
+        // mirroring `docker compose down`, which needs its compose file.
+        let mut svc = mk_svc("svc", sh("true"), sh("test -f needed.conf"));
+        svc.workdir = Some(Workdir {
+            mode: WorkdirMode::Ephemeral,
+            path: None,
+        });
+        svc.files.insert(
+            "needed.conf".to_string(),
+            "unit-declared content\n".to_string(),
+        );
+
+        let rev = mk_rev("r1", vec![svc.clone()], vec![], vec![]);
+        mgr.set_desired_units(rev, vec![]).await?;
+        mgr.reconcile_dirty().await?;
+
+        // Simulate the workdir being empty at stop time — exactly what an
+        // ephemeral workdir looks like after a runtime restart.
+        let wd = mgr
+            .resolve_workdir_for(&svc.id, svc.workdir.as_ref())
+            .await?;
+        let _ = std::fs::remove_file(wd.join("needed.conf"));
+        assert!(
+            !wd.join("needed.conf").exists(),
+            "precondition: declared file must be absent before the stop"
+        );
+
+        mgr.stop_service(&svc, "r1", &wd).await.map_err(|e| {
+            anyhow!("stop must materialize the unit's declared files first: {e:#}")
+        })?;
+
         Ok(())
     }
 }

--- a/m87-server/src/api/deploy_spec.rs
+++ b/m87-server/src/api/deploy_spec.rs
@@ -549,9 +549,17 @@ async fn update_unit_lifecycle(
     let options = mongodb::options::UpdateOptions::builder()
         .array_filters(vec![array_filter])
         .build();
-    for section in ["services", "observers", "jobs"] {
+    // The unit lives in exactly ONE of these sections, so the other two are
+    // expected to miss — and a positional array update against a section the
+    // revision doesn't have is a Mongo error. Propagating that turned a fully
+    // successful lifecycle change into a 500: the device had already been sent
+    // the update and acted on it, while the caller saw a server error.
+    //
+    // Jobs live under the canonical `job_defs` key; the legacy `jobs` array is
+    // ignored by the read side, so mutating it here had no effect.
+    for section in ["services", "observers", "job_defs"] {
         let path = format!("revision.{section}.$[elem].lifecycle");
-        let _ = state
+        if let Err(e) = state
             .db
             .deploy_revisions()
             .update_one(
@@ -559,7 +567,12 @@ async fn update_unit_lifecycle(
                 doc! { "$set": { path: &lifecycle_bson } },
             )
             .with_options(options.clone())
-            .await?;
+            .await
+        {
+            tracing::debug!(
+                "lifecycle mirror for '{unit_id}' skipped section '{section}': {e}"
+            );
+        }
     }
 
     Ok(ServerResponse::builder()


### PR DESCRIPTION
`apply_service` writes a unit's `files:` into the workdir before running startup steps, but `stop_service` did not. With `workdir: ephemeral` the workdir comes back empty after a runtime restart, so any stop step that uses a declared file fails — and that is the normal case, since `docker compose down` cannot run without its compose file:

    no configuration file provided: not found      (exit 1)

The failure is not cosmetic. A failed stop keeps the unit in the dirty set, and unlike the start path the stop path has no backoff, so reconcile retried it about twice a second indefinitely: a self-inflicted denial of service that consumes CPU and spawns a docker invocation per iteration on the most constrained devices.

Nothing is wrong with such a spec: it declares the file, so the runtime should provide it whenever it runs that unit's steps. Materialization is best-effort here — a failure to write the files is logged rather than masking the stop error itself.

Test (written first, failed with the same exit code 1 as production): a unit with an ephemeral workdir and a stop step that requires a declared file must stop successfully even when the workdir is empty beforehand.

Note: the missing backoff on repeated stop failures is a separate issue and is not addressed here.